### PR TITLE
humann_genefamilies_genus_level: Fix a dictionary parsing and add functional test

### DIFF
--- a/humann/tests/cfg.py
+++ b/humann/tests/cfg.py
@@ -185,6 +185,11 @@ merge_abundance_pathways_input=os.path.join(data_folder, merge_abundance_folder,
 merge_abundance_output=os.path.join(data_folder, merge_abundance_folder, "merge_output.tsv")
 merge_abundance_remove_taxonomy_output=os.path.join(data_folder, merge_abundance_folder, "merge_output_remove_taxonomy.tsv")
 
+# Files for creating genefamilies genus level
+genefamilies_genus_level_folder="tooltest-genefamilies_genus_level"
+genefamilies_genus_level_input=os.path.join(data_folder, genefamilies_genus_level_folder, "demo_genefamilies.tsv")
+genefamilies_genus_level_output=os.path.join(data_folder, genefamilies_genus_level_folder, "genus_level_genefamilies.tsv")
+
 # Get the locations of the demo chocophlan and uniref databases
 example_demo_data_folder=os.path.join(os.path.dirname(os.path.abspath(__file__)),os.pardir,"data")
 chocophlan_example_demo_folder=os.path.join(example_demo_data_folder, "chocophlan_DEMO")
@@ -202,3 +207,4 @@ renorm_cpm_output_biom=os.path.join(data_folder, renorm_folder, "renorm_table-cp
 multi_sample_genefamilies_biom = os.path.join(data_folder, "multi_sample_genefamilies.biom")
 multi_sample_genefamilies_split_basename_biom="multi_sample_biom_genefamilies_"
 multi_sample_split_files_biom=["multi_sample_genefamilies_sample1.biom","multi_sample_genefamilies_sample2.biom"]
+

--- a/humann/tests/data/tooltest-genefamilies_genus_level/demo_genefamilies.tsv
+++ b/humann/tests/data/tooltest-genefamilies_genus_level/demo_genefamilies.tsv
@@ -1,0 +1,2927 @@
+# Gene Family	demo_Abundance-RPKs
+UNMAPPED	100.0000000000
+UniRef50_R5IH84	37.0370370370
+UniRef50_R5IH84|g__Bacteroides.s__Bacteroides_stercoris	37.0370370370
+UniRef50_B0NQY6	25.6410256410
+UniRef50_B0NQY6|g__Bacteroides.s__Bacteroides_stercoris	25.6410256410
+UniRef50_F3PHD0	25.6410256410
+UniRef50_F3PHD0|g__Bacteroides.s__Bacteroides_stercoris	25.6410256410
+UniRef50_B0NP96	23.8095238095
+UniRef50_B0NP96|g__Bacteroides.s__Bacteroides_stercoris	23.8095238095
+UniRef50_B0NTS9	21.2765957447
+UniRef50_B0NTS9|g__Bacteroides.s__Bacteroides_stercoris	21.2765957447
+UniRef50_R6FNM5	16.1290322581
+UniRef50_R6FNM5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	16.1290322581
+UniRef50_A6L108	15.6250000000
+UniRef50_A6L108|g__Bacteroides.s__Bacteroides_stercoris	15.6250000000
+UniRef50_B0NWG2	13.3333333333
+UniRef50_B0NWG2|g__Bacteroides.s__Bacteroides_stercoris	13.3333333333
+UniRef50_R6XJU3: Sec-independent protein translocase protein TatA	12.3456790123
+UniRef50_R6XJU3: Sec-independent protein translocase protein TatA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	12.3456790123
+UniRef50_R5JQA6	11.9047619048
+UniRef50_R5JQA6|g__Bacteroides.s__Bacteroides_stercoris	11.9047619048
+UniRef50_Q8A9G3	10.7526881720
+UniRef50_Q8A9G3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	10.7526881720
+UniRef50_B6YQ01: 50S ribosomal protein L11	10.2040816327
+UniRef50_B6YQ01: 50S ribosomal protein L11|g__Bacteroides.s__Bacteroides_stercoris	6.8027210884
+UniRef50_B6YQ01: 50S ribosomal protein L11|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.4013605442
+UniRef50_R5FJB9: Conjugative transposon TraN protein	9.9476081017
+UniRef50_R5FJB9: Conjugative transposon TraN protein|g__Bacteroides.s__Bacteroides_stercoris	7.3480337630
+UniRef50_R5FJB9: Conjugative transposon TraN protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5995743387
+UniRef50_R5BGD6	9.8039215686
+UniRef50_R5BGD6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	9.8039215686
+UniRef50_R7JA39: PF13711 domain protein	9.8039215686
+UniRef50_R7JA39: PF13711 domain protein|g__Bacteroides.s__Bacteroides_stercoris	9.8039215686
+UniRef50_E1WUR5	9.5238095238
+UniRef50_E1WUR5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	9.5238095238
+UniRef50_B6YQ88: 30S ribosomal protein S7	9.1743119266
+UniRef50_B6YQ88: 30S ribosomal protein S7|g__Bacteroides.s__Bacteroides_stercoris	6.1162079511
+UniRef50_B6YQ88: 30S ribosomal protein S7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.0581039755
+UniRef50_Q2S3Q3: 50S ribosomal protein L24	9.0871771906
+UniRef50_Q2S3Q3: 50S ribosomal protein L24|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.9523809524
+UniRef50_Q2S3Q3: 50S ribosomal protein L24|g__Bacteroides.s__Bacteroides_stercoris	3.1347962382
+UniRef50_C1A930: 50S ribosomal protein L27	8.3333333333
+UniRef50_C1A930: 50S ribosomal protein L27|g__Bacteroides.s__Bacteroides_stercoris	8.3333333333
+UniRef50_B0NV53	8.1967213115
+UniRef50_B0NV53|g__Bacteroides.s__Bacteroides_stercoris	8.1967213115
+UniRef50_R6AHC9	8.1967213115
+UniRef50_R6AHC9|g__Bacteroides.s__Bacteroides_stercoris	8.1967213115
+UniRef50_R5F6Z7	7.7519379845
+UniRef50_R5F6Z7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	7.7519379845
+UniRef50_R6M7F9	7.7519379845
+UniRef50_R6M7F9|g__Bacteroides.s__Bacteroides_stercoris	7.7519379845
+UniRef50_A6KYI0: 50S ribosomal protein L6	7.1428571429
+UniRef50_A6KYI0: 50S ribosomal protein L6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	7.1428571429
+UniRef50_R5CEU4	7.0921985816
+UniRef50_R5CEU4|g__Bacteroides.s__Bacteroides_stercoris	7.0921985816
+UniRef50_R5I0U3	7.0921985816
+UniRef50_R5I0U3|g__Bacteroides.s__Bacteroides_stercoris	7.0921985816
+UniRef50_Q8A3G7	6.8027210884
+UniRef50_Q8A3G7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	6.8027210884
+UniRef50_Q5L9B7: 50S ribosomal protein L9	6.6666666667
+UniRef50_Q5L9B7: 50S ribosomal protein L9|g__Bacteroides.s__Bacteroides_stercoris	6.6666666667
+UniRef50_R5V945	6.6666666667
+UniRef50_R5V945|g__Bacteroides.s__Bacteroides_stercoris	6.6666666667
+UniRef50_I0Q078	6.5789473684
+UniRef50_I0Q078|unclassified	6.5789473684
+UniRef50_A0A015YH91	6.4516129032
+UniRef50_A0A015YH91|g__Bacteroides.s__Bacteroides_stercoris	6.4516129032
+UniRef50_D1KAI8	6.4102564103
+UniRef50_D1KAI8|g__Bacteroides.s__Bacteroides_stercoris	6.4102564103
+UniRef50_A6KY76	6.2893081761
+UniRef50_A6KY76|g__Bacteroides.s__Bacteroides_stercoris	6.2893081761
+UniRef50_R6L4G2	6.2893081761
+UniRef50_R6L4G2|g__Bacteroides.s__Bacteroides_stercoris	6.2893081761
+UniRef50_W0ESG7: DNA-binding protein	6.2893081761
+UniRef50_W0ESG7: DNA-binding protein|g__Bacteroides.s__Bacteroides_stercoris	6.2893081761
+UniRef50_A0A016LIR2	6.2500000000
+UniRef50_A0A016LIR2|g__Bacteroides.s__Bacteroides_stercoris	6.2500000000
+UniRef50_R7IYZ7	6.1728395062
+UniRef50_R7IYZ7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	6.1728395062
+UniRef50_F5XD83: Conjugative transposon protein TraK	5.8297152408
+UniRef50_F5XD83: Conjugative transposon protein TraK|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.7200105995
+UniRef50_F5XD83: Conjugative transposon protein TraK|g__Bacteroides.s__Bacteroides_stercoris	2.1097046414
+UniRef50_R6KK61	5.7142857143
+UniRef50_R6KK61|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.7142857143
+UniRef50_P0A864: Thiol peroxidase	5.6497175141
+UniRef50_P0A864: Thiol peroxidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.6497175141
+UniRef50_R5JE58	5.6497175141
+UniRef50_R5JE58|g__Bacteroides.s__Bacteroides_stercoris	5.6497175141
+UniRef50_F9D2T3: Ribosome-binding factor A	5.4644808743
+UniRef50_F9D2T3: Ribosome-binding factor A|g__Bacteroides.s__Bacteroides_stercoris	5.4644808743
+UniRef50_Q8A7R3	5.3763440860
+UniRef50_Q8A7R3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.3763440860
+UniRef50_R6EAJ7	5.3763440860
+UniRef50_R6EAJ7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.3763440860
+UniRef50_R7PE88: Methylglyoxal synthase	5.2940064284
+UniRef50_R7PE88: Methylglyoxal synthase|g__Bacteroides.s__Bacteroides_stercoris	2.7100271003
+UniRef50_R7PE88: Methylglyoxal synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5839793282
+UniRef50_I3YN79	5.2910052910
+UniRef50_I3YN79|g__Bacteroides.s__Bacteroides_stercoris	5.2910052910
+UniRef50_Q5LIQ7: Shikimate kinase	5.2910052910
+UniRef50_Q5LIQ7: Shikimate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.2910052910
+UniRef50_R5C4D7	5.2083333333
+UniRef50_R5C4D7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.2083333333
+UniRef50_B0NU42	5.1282051282
+UniRef50_B0NU42|g__Bacteroides.s__Bacteroides_stercoris	5.1282051282
+UniRef50_E1WVZ0	5.1282051282
+UniRef50_E1WVZ0|g__Bacteroides.s__Bacteroides_stercoris	5.1282051282
+UniRef50_R5JPY8: RNA polymerase sigma factor	5.1282051282
+UniRef50_R5JPY8: RNA polymerase sigma factor|g__Bacteroides.s__Bacteroides_stercoris	5.1282051282
+UniRef50_R6KNV0: Thioredoxin	5.1282051282
+UniRef50_R6KNV0: Thioredoxin|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.1282051282
+UniRef50_Q8A0V3: Pyridoxine 5'-phosphate synthase	5.1020408163
+UniRef50_Q8A0V3: Pyridoxine 5'-phosphate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.1020408163
+UniRef50_Q89ZC3: 7-carboxy-7-deazaguanine synthase	5.0125313283
+UniRef50_Q89ZC3: 7-carboxy-7-deazaguanine synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	5.0125313283
+UniRef50_A6KYF8	4.9751243781
+UniRef50_A6KYF8|g__Bacteroides.s__Bacteroides_stercoris	4.9751243781
+UniRef50_I3YIX3	4.9751243781
+UniRef50_I3YIX3|g__Bacteroides.s__Bacteroides_stercoris	4.9751243781
+UniRef50_Q6ADC9: 50S ribosomal protein L20	4.9751243781
+UniRef50_Q6ADC9: 50S ribosomal protein L20|g__Bacteroides.s__Bacteroides_stercoris	4.9751243781
+UniRef50_R7J836	4.9504950495
+UniRef50_R7J836|g__Bacteroides.s__Bacteroides_stercoris	4.9504950495
+UniRef50_Q7MT66: 30S ribosomal protein S16	4.9382716049
+UniRef50_Q7MT66: 30S ribosomal protein S16|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.9382716049
+UniRef50_E1WVZ2	4.9019607843
+UniRef50_E1WVZ2|g__Bacteroides.s__Bacteroides_stercoris	4.9019607843
+UniRef50_Q8A4V8: 50S ribosomal protein L19	4.9019607843
+UniRef50_Q8A4V8: 50S ribosomal protein L19|g__Bacteroides.s__Bacteroides_stercoris	4.9019607843
+UniRef50_B0NW87	4.7619047619
+UniRef50_B0NW87|g__Bacteroides.s__Bacteroides_stercoris	4.7619047619
+UniRef50_Q64WL5: Conserved protein found in conjugate transposon	4.7393364929
+UniRef50_Q64WL5: Conserved protein found in conjugate transposon|g__Bacteroides.s__Bacteroides_stercoris	4.7393364929
+UniRef50_A6L9Z9	4.6948356808
+UniRef50_A6L9Z9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.6948356808
+UniRef50_G8UNP4	4.6620046620
+UniRef50_G8UNP4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.6620046620
+UniRef50_Q64NX2	4.6296296296
+UniRef50_Q64NX2|g__Bacteroides.s__Bacteroides_stercoris	4.6296296296
+UniRef50_E6SNW2	4.5662100457
+UniRef50_E6SNW2|g__Bacteroides.s__Bacteroides_stercoris	2.2831050228
+UniRef50_E6SNW2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2831050228
+UniRef50_R5M4C8	4.4444444444
+UniRef50_R5M4C8|g__Bacteroides.s__Bacteroides_stercoris	4.4444444444
+UniRef50_R5RJG0	4.4444444444
+UniRef50_R5RJG0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.4444444444
+UniRef50_A9B436: 30S ribosomal protein S4	4.3859649123
+UniRef50_A9B436: 30S ribosomal protein S4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.3859649123
+UniRef50_D6D2K4: Putative fluoride ion transporter CrcB	4.3859649123
+UniRef50_D6D2K4: Putative fluoride ion transporter CrcB|g__Bacteroides.s__Bacteroides_stercoris	4.3859649123
+UniRef50_Q5LG50: Dephospho-CoA kinase	4.3010752688
+UniRef50_Q5LG50: Dephospho-CoA kinase|g__Bacteroides.s__Bacteroides_stercoris	2.1505376344
+UniRef50_Q5LG50: Dephospho-CoA kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1505376344
+UniRef50_Q8A8Q0	4.2735042735
+UniRef50_Q8A8Q0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.2735042735
+UniRef50_R5JC25: 5-formyltetrahydrofolate cyclo-ligase	4.2735042735
+UniRef50_R5JC25: 5-formyltetrahydrofolate cyclo-ligase|g__Bacteroides.s__Bacteroides_stercoris	4.2735042735
+UniRef50_Q8AB79: Excisionase	4.2553191489
+UniRef50_Q8AB79: Excisionase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.2553191489
+UniRef50_I3YK46: Bacteroides conjugative transposon TraK protein	4.2194092827
+UniRef50_I3YK46: Bacteroides conjugative transposon TraK protein|g__Bacteroides.s__Bacteroides_stercoris	4.2194092827
+UniRef50_R5RND9	4.2194092827
+UniRef50_R5RND9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.2194092827
+UniRef50_Q2S3P1: 30S ribosomal protein S11	4.1666666667
+UniRef50_Q2S3P1: 30S ribosomal protein S11|g__Bacteroides.s__Bacteroides_stercoris	4.1666666667
+UniRef50_Q650G4	4.1666666667
+UniRef50_Q650G4|g__Bacteroides.s__Bacteroides_stercoris	4.1666666667
+UniRef50_Q89AX0: Electron transport complex subunit A	4.0671134421
+UniRef50_Q89AX0: Electron transport complex subunit A|g__Bacteroides.s__Bacteroides_stercoris	4.0671134421
+UniRef50_A6KZM8: Chloramphenicol acetyltransferase	4.0404040404
+UniRef50_A6KZM8: Chloramphenicol acetyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.0404040404
+UniRef50_I8UXY9	4.0404040404
+UniRef50_I8UXY9|g__Bacteroides.s__Bacteroides_stercoris	4.0404040404
+UniRef50_Q8A980	4.0160642570
+UniRef50_Q8A980|g__Bacteroides.s__Bacteroides_thetaiotaomicron	4.0160642570
+UniRef50_A6KYK1: Transposase	3.9840637450
+UniRef50_A6KYK1: Transposase|g__Bacteroides.s__Bacteroides_stercoris	3.9840637450
+UniRef50_F0R8X8: Tetracycline regulation of excision, RteC	3.9682539683
+UniRef50_F0R8X8: Tetracycline regulation of excision, RteC|g__Bacteroides.s__Bacteroides_stercoris	3.9682539683
+UniRef50_R6ZRN7	3.9482291375
+UniRef50_R6ZRN7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.9482291375
+UniRef50_R7JJL0: 4-phosphoerythronate dehydrogenase	3.8910505837
+UniRef50_R7JJL0: 4-phosphoerythronate dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	2.5940337224
+UniRef50_R7JJL0: 4-phosphoerythronate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2970168612
+UniRef50_R6LA73: Pentapeptide repeat protein	3.8761000124
+UniRef50_R6LA73: Pentapeptide repeat protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9493177388
+UniRef50_R6LA73: Pentapeptide repeat protein|g__Bacteroides.s__Bacteroides_stercoris	1.9267822736
+UniRef50_R6FL32	3.8535645472
+UniRef50_R6FL32|g__Bacteroides.s__Bacteroides_stercoris	3.8535645472
+UniRef50_C9KYM2	3.8314176245
+UniRef50_C9KYM2|g__Bacteroides.s__Bacteroides_stercoris	3.8314176245
+UniRef50_R7NYP7: KDPG and KHG aldolase	3.8314176245
+UniRef50_R7NYP7: KDPG and KHG aldolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.8314176245
+UniRef50_R5JQ93	3.7878787879
+UniRef50_R5JQ93|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.7878787879
+UniRef50_F0R3P4: Conjugate transposon protein	3.7453183521
+UniRef50_F0R3P4: Conjugate transposon protein|g__Bacteroides.s__Bacteroides_stercoris	3.7453183521
+UniRef50_R5UTE7	3.7453183521
+UniRef50_R5UTE7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.7453183521
+UniRef50_R6B0U5	3.6630036630
+UniRef50_R6B0U5|g__Bacteroides.s__Bacteroides_stercoris	3.6630036630
+UniRef50_F0R927: Phosphate-specific transport system accessory protein PhoU	3.6312112825
+UniRef50_F0R927: Phosphate-specific transport system accessory protein PhoU|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8518518519
+UniRef50_F0R927: Phosphate-specific transport system accessory protein PhoU|g__Bacteroides.s__Bacteroides_stercoris	1.7793594306
+UniRef50_Q8A8Q5: Transposase	3.6231884058
+UniRef50_Q8A8Q5: Transposase|g__Bacteroides.s__Bacteroides_stercoris	3.6231884058
+UniRef50_Q8A9S1: 2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase	3.6231884058
+UniRef50_Q8A9S1: 2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase|g__Bacteroides.s__Bacteroides_stercoris	3.6231884058
+UniRef50_R6J655	3.6140979689
+UniRef50_R6J655|g__Bacteroides.s__Bacteroides_stercoris	3.6140979689
+UniRef50_A6KYA8	3.5815057073
+UniRef50_A6KYA8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8115942029
+UniRef50_A6KYA8|g__Bacteroides.s__Bacteroides_stercoris	1.7699115044
+UniRef50_A6KXA8: Transposase	3.5587188612
+UniRef50_A6KXA8: Transposase|g__Bacteroides.s__Bacteroides_stercoris	3.5587188612
+UniRef50_R5CEL5: Electron transport complex subunit D	3.5587188612
+UniRef50_R5CEL5: Electron transport complex subunit D|g__Bacteroides.s__Bacteroides_stercoris	2.3724792408
+UniRef50_R5CEL5: Electron transport complex subunit D|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1862396204
+UniRef50_Q8A268	3.5587188612
+UniRef50_Q8A268|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.5587188612
+UniRef50_P61913: Deoxyuridine 5'-triphosphate nucleotidohydrolase	3.5460992908
+UniRef50_P61913: Deoxyuridine 5'-triphosphate nucleotidohydrolase|g__Bacteroides.s__Bacteroides_stercoris	3.5460992908
+UniRef50_Q73WG1: Serine hydroxymethyltransferase	3.5366931919
+UniRef50_Q73WG1: Serine hydroxymethyltransferase|g__Bacteroides.s__Bacteroides_stercoris	2.6525198939
+UniRef50_Q73WG1: Serine hydroxymethyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8841732980
+UniRef50_F9D7B9: ISPg5 transposase Orf2	3.5087719298
+UniRef50_F9D7B9: ISPg5 transposase Orf2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.5087719298
+UniRef50_Q67JV0: 50S ribosomal protein L16	3.5087719298
+UniRef50_Q67JV0: 50S ribosomal protein L16|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.5087719298
+UniRef50_R5BFK2: Hsp20/alpha crystallin family protein	3.5087719298
+UniRef50_R5BFK2: Hsp20/alpha crystallin family protein|g__Bacteroides.s__Bacteroides_stercoris	3.5087719298
+UniRef50_R5KHY4: 2-oxoglutarate:acceptor oxidoreductase subunit OorB	3.5006214724
+UniRef50_R5KHY4: 2-oxoglutarate:acceptor oxidoreductase subunit OorB|g__Bacteroides.s__Bacteroides_stercoris	2.3391812865
+UniRef50_R5KHY4: 2-oxoglutarate:acceptor oxidoreductase subunit OorB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1614401858
+UniRef50_R7KL41	3.4722222222
+UniRef50_R7KL41|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.4722222222
+UniRef50_Q8A6E2	3.4364261168
+UniRef50_Q8A6E2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.4364261168
+UniRef50_A6L0N6: Conserved protein found in conjugate transposon	3.4018488003
+UniRef50_A6L0N6: Conserved protein found in conjugate transposon|g__Bacteroides.s__Bacteroides_stercoris	2.5327759057
+UniRef50_A6L0N6: Conserved protein found in conjugate transposon|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8690728946
+UniRef50_Q8A8J6: Glyoxalase family-like protein	3.4013605442
+UniRef50_Q8A8J6: Glyoxalase family-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.4013605442
+UniRef50_A6L552: DNA repair protein	3.3670033670
+UniRef50_A6L552: DNA repair protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.3670033670
+UniRef50_F3ZPA3: Transcriptional regulator, MarR family	3.3670033670
+UniRef50_F3ZPA3: Transcriptional regulator, MarR family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.3670033670
+UniRef50_R5NGD9	3.3670033670
+UniRef50_R5NGD9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.3670033670
+UniRef50_P38674: Ketol-acid reductoisomerase, mitochondrial	3.3557046980
+UniRef50_P38674: Ketol-acid reductoisomerase, mitochondrial|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2371364653
+UniRef50_P38674: Ketol-acid reductoisomerase, mitochondrial|g__Bacteroides.s__Bacteroides_stercoris	1.1185682327
+UniRef50_Q8A4J1	3.3333333333
+UniRef50_Q8A4J1|g__Bacteroides.s__Bacteroides_stercoris	3.3333333333
+UniRef50_R5K2Q8	3.3286136573
+UniRef50_R5K2Q8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7636684303
+UniRef50_R5K2Q8|g__Bacteroides.s__Bacteroides_stercoris	1.5649452269
+UniRef50_G9S1V7	3.3085194376
+UniRef50_G9S1V7|g__Bacteroides.s__Bacteroides_stercoris	1.6542597188
+UniRef50_G9S1V7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6542597188
+UniRef50_Q8A7E3	3.3003300330
+UniRef50_Q8A7E3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.3003300330
+UniRef50_Q5LAB4: 3-isopropylmalate dehydrogenase	3.2967112501
+UniRef50_Q5LAB4: 3-isopropylmalate dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	2.2002200220
+UniRef50_Q5LAB4: 3-isopropylmalate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0964912281
+UniRef50_O83553: Pyrophosphate--fructose 6-phosphate 1-phosphotransferase	3.2799134236
+UniRef50_O83553: Pyrophosphate--fructose 6-phosphate 1-phosphotransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9439080796
+UniRef50_O83553: Pyrophosphate--fructose 6-phosphate 1-phosphotransferase|g__Bacteroides.s__Bacteroides_stercoris	1.3360053440
+UniRef50_P0AC90: GDP-mannose 4,6-dehydratase	3.2397937988
+UniRef50_P0AC90: GDP-mannose 4,6-dehydratase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1610451473
+UniRef50_P0AC90: GDP-mannose 4,6-dehydratase|g__Bacteroides.s__Bacteroides_stercoris	1.0787486516
+UniRef50_A6KYW4	3.2362459547
+UniRef50_A6KYW4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.2362459547
+UniRef50_B0NTK8	3.2362459547
+UniRef50_B0NTK8|g__Bacteroides.s__Bacteroides_stercoris	3.2362459547
+UniRef50_W0F5J4: Phosphonate ABC transporter ATP-binding protein	3.2206119163
+UniRef50_W0F5J4: Phosphonate ABC transporter ATP-binding protein|g__Bacteroides.s__Bacteroides_stercoris	3.2206119163
+UniRef50_G8UMN4: Prephenate dehydrogenase	3.2051282051
+UniRef50_G8UMN4: Prephenate dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_G8UMN4: Prephenate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6025641026
+UniRef50_R6SFG3	3.2051282051
+UniRef50_R6SFG3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.2051282051
+UniRef50_R7EPN1: C_GCAxxG_C_C family protein	3.2051282051
+UniRef50_R7EPN1: C_GCAxxG_C_C family protein|g__Bacteroides.s__Bacteroides_stercoris	3.2051282051
+UniRef50_E1WLE0	3.1976075454
+UniRef50_E1WLE0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6103059581
+UniRef50_E1WLE0|g__Bacteroides.s__Bacteroides_stercoris	1.5873015873
+UniRef50_H1Y602: AMP nucleosidase	3.1897926635
+UniRef50_H1Y602: AMP nucleosidase|g__Bacteroides.s__Bacteroides_stercoris	3.1897926635
+UniRef50_A6LCB6: Nucleoside diphosphate kinase	3.1746031746
+UniRef50_A6LCB6: Nucleoside diphosphate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.1746031746
+UniRef50_B3ESB4: Transcription elongation factor GreA	3.1746031746
+UniRef50_B3ESB4: Transcription elongation factor GreA|g__Bacteroides.s__Bacteroides_stercoris	3.1746031746
+UniRef50_D6CYB8: Transcriptional regulator, AsnC family	3.1746031746
+UniRef50_D6CYB8: Transcriptional regulator, AsnC family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.1746031746
+UniRef50_R5CNZ4	3.1746031746
+UniRef50_R5CNZ4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.1746031746
+UniRef50_R7D088: Competence-damage inducible protein	3.1446540881
+UniRef50_R7D088: Competence-damage inducible protein|g__Bacteroides.s__Bacteroides_stercoris	3.1446540881
+UniRef50_E6SQ70	3.1152647975
+UniRef50_E6SQ70|g__Bacteroides.s__Bacteroides_stercoris	3.1152647975
+UniRef50_R6KN92	3.0959752322
+UniRef50_R6KN92|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.0959752322
+UniRef50_R7EKD0	3.0864197531
+UniRef50_R7EKD0|g__Bacteroides.s__Bacteroides_stercoris	3.0864197531
+UniRef50_R7HMB1	3.0864197531
+UniRef50_R7HMB1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.0864197531
+UniRef50_R6A3L9	3.0581039755
+UniRef50_R6A3L9|g__Bacteroides.s__Bacteroides_stercoris	3.0581039755
+UniRef50_R7NQ15: Gluconate 5-dehydrogenase	3.0581039755
+UniRef50_R7NQ15: Gluconate 5-dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.0581039755
+UniRef50_R5ALC1	3.0303030303
+UniRef50_R5ALC1|g__Bacteroides.s__Bacteroides_stercoris	2.0202020202
+UniRef50_R5ALC1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0101010101
+UniRef50_R6BED5	3.0303030303
+UniRef50_R6BED5|g__Bacteroides.s__Bacteroides_stercoris	3.0303030303
+UniRef50_X5D7K7: Transcriptional regulator	3.0303030303
+UniRef50_X5D7K7: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	3.0303030303
+UniRef50_R6C5B4: 3'(2') 5'-bisphosphate nucleotidase	3.0235715167
+UniRef50_R6C5B4: 3'(2') 5'-bisphosphate nucleotidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5220700152
+UniRef50_R6C5B4: 3'(2') 5'-bisphosphate nucleotidase|g__Bacteroides.s__Bacteroides_stercoris	1.5015015015
+UniRef50_E1WS50: Ferritin	3.0030030030
+UniRef50_E1WS50: Ferritin|g__Bacteroides.s__Bacteroides_stercoris	3.0030030030
+UniRef50_E6SQW3	2.9761904762
+UniRef50_E6SQW3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.9761904762
+UniRef50_A6KYS6: S-ribosylhomocysteine lyase	2.9498525074
+UniRef50_A6KYS6: S-ribosylhomocysteine lyase|g__Bacteroides.s__Bacteroides_stercoris	2.9498525074
+UniRef50_F2KU88: Acyltransferase	2.9498525074
+UniRef50_F2KU88: Acyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.9498525074
+UniRef50_Q8A4R1	2.9498525074
+UniRef50_Q8A4R1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.9498525074
+UniRef50_A0M572: 50S ribosomal protein L17	2.9239766082
+UniRef50_A0M572: 50S ribosomal protein L17|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.9239766082
+UniRef50_A5FAU9: Phosphodiesterase, MJ0936 family	2.9239766082
+UniRef50_A5FAU9: Phosphodiesterase, MJ0936 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.9239766082
+UniRef50_R5W452	2.8985507246
+UniRef50_R5W452|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8985507246
+UniRef50_Q64XV3	2.8735632184
+UniRef50_Q64XV3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8735632184
+UniRef50_Q8A392	2.8735632184
+UniRef50_Q8A392|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8735632184
+UniRef50_R6JAQ7	2.8735632184
+UniRef50_R6JAQ7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8735632184
+UniRef50_R6Y8G9: Phosphate ABC transporter permease protein PstC	2.8653295129
+UniRef50_R6Y8G9: Phosphate ABC transporter permease protein PstC|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8653295129
+UniRef50_U5Q7A5: Spore coat polysaccharide biosynthesis protein spsK	2.8490548808
+UniRef50_U5Q7A5: Spore coat polysaccharide biosynthesis protein spsK|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4306151645
+UniRef50_U5Q7A5: Spore coat polysaccharide biosynthesis protein spsK|g__Bacteroides.s__Bacteroides_stercoris	1.4184397163
+UniRef50_Q8A9U9: ATP synthase subunit b	2.8490028490
+UniRef50_Q8A9U9: ATP synthase subunit b|g__Bacteroides.s__Bacteroides_stercoris	2.8490028490
+UniRef50_F3ZTK2: Alkyl hydroperoxide reductase/ Thiol specific antioxidant/ Mal allergen	2.8248587571
+UniRef50_F3ZTK2: Alkyl hydroperoxide reductase/ Thiol specific antioxidant/ Mal allergen|g__Bacteroides.s__Bacteroides_stercoris	2.8248587571
+UniRef50_Q89YJ6: Histone-like bacterial DNA-binding protein	2.8248587571
+UniRef50_Q89YJ6: Histone-like bacterial DNA-binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8248587571
+UniRef50_Q8A8J1: Glycoside transferase family 2	2.8129395218
+UniRef50_Q8A8J1: Glycoside transferase family 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.8129395218
+UniRef50_E6SWE8: Integrase family protein	2.8117442782
+UniRef50_E6SWE8: Integrase family protein|g__Bacteroides.s__Bacteroides_stercoris	1.8701246925
+UniRef50_E6SWE8: Integrase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9416195857
+UniRef50_R7EKK1: Sigma-70 family RNA polymerase sigma factor	2.7777777778
+UniRef50_R7EKK1: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7777777778
+UniRef50_R7NKV2: Sigma-70 family RNA polymerase sigma factor	2.7777777778
+UniRef50_R7NKV2: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7777777778
+UniRef50_F0R5K9	2.7624309392
+UniRef50_F0R5K9|g__Bacteroides.s__Bacteroides_stercoris	2.7624309392
+UniRef50_E4T6S0	2.7599640775
+UniRef50_E4T6S0|g__Bacteroides.s__Bacteroides_stercoris	2.7599640775
+UniRef50_Q8D1X9: Phosphoenolpyruvate carboxykinase [ATP]	2.7434842250
+UniRef50_Q8D1X9: Phosphoenolpyruvate carboxykinase [ATP]|g__Bacteroides.s__Bacteroides_stercoris	2.0576131687
+UniRef50_Q8D1X9: Phosphoenolpyruvate carboxykinase [ATP]|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6858710562
+UniRef50_R5J495	2.7434842250
+UniRef50_R5J495|g__Bacteroides.s__Bacteroides_stercoris	2.7434842250
+UniRef50_R5U1K5: TonB family domain-containing protein	2.7434842250
+UniRef50_R5U1K5: TonB family domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7434842250
+UniRef50_R6A758: Purine or other phosphorylase family 1	2.7434842250
+UniRef50_R6A758: Purine or other phosphorylase family 1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7434842250
+UniRef50_R6ZQ01	2.7372989330
+UniRef50_R6ZQ01|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8315018315
+UniRef50_R6ZQ01|g__Bacteroides.s__Bacteroides_stercoris	0.9057971014
+UniRef50_D9RT31: Outer membrane protein	2.7322404372
+UniRef50_D9RT31: Outer membrane protein|g__Bacteroides.s__Bacteroides_stercoris	2.7322404372
+UniRef50_F0R3Q0: Relaxase/mobilization nuclease family protein	2.7322404372
+UniRef50_F0R3Q0: Relaxase/mobilization nuclease family protein|g__Bacteroides.s__Bacteroides_stercoris	2.7322404372
+UniRef50_R5S3H1: Relaxase/mobilization nuclease domain protein	2.7322404372
+UniRef50_R5S3H1: Relaxase/mobilization nuclease domain protein|g__Bacteroides.s__Bacteroides_stercoris	2.7322404372
+UniRef50_B4SSU7: Nitrilase/cyanide hydratase and apolipoprotein N-acyltransferase	2.7210884354
+UniRef50_B4SSU7: Nitrilase/cyanide hydratase and apolipoprotein N-acyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7210884354
+UniRef50_R6RT35	2.7173913043
+UniRef50_R6RT35|g__Bacteroides.s__Bacteroides_stercoris	2.7173913043
+UniRef50_Q8A4L6	2.7100271003
+UniRef50_Q8A4L6|g__Bacteroides.s__Bacteroides_stercoris	2.7100271003
+UniRef50_R5ND35	2.7100271003
+UniRef50_R5ND35|g__Bacteroides.s__Bacteroides_stercoris	2.7100271003
+UniRef50_R6JCU1: Glutaminase A	2.7100271003
+UniRef50_R6JCU1: Glutaminase A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.7100271003
+UniRef50_R7PA29: Malonyl CoA-acyl carrier protein transacylase	2.7100271003
+UniRef50_R7PA29: Malonyl CoA-acyl carrier protein transacylase|g__Bacteroides.s__Bacteroides_stercoris	2.7100271003
+UniRef50_R6AI91: Conserved domain protein	2.6954177898
+UniRef50_R6AI91: Conserved domain protein|g__Bacteroides.s__Bacteroides_stercoris	2.6954177898
+UniRef50_F0R2U7: Integrase catalytic region	2.6881720430
+UniRef50_F0R2U7: Integrase catalytic region|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.6881720430
+UniRef50_B5Y9A7: Glutamate formiminotransferase	2.6773761714
+UniRef50_B5Y9A7: Glutamate formiminotransferase|g__Bacteroides.s__Bacteroides_stercoris	2.6773761714
+UniRef50_R5S1C6: 5-methyltetrahydrofolate-homocysteine methyltransferase	2.6560424967
+UniRef50_R5S1C6: 5-methyltetrahydrofolate-homocysteine methyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.6560424967
+UniRef50_Q4UY06: Sulfate adenylyltransferase subunit 2	2.6298590147
+UniRef50_Q4UY06: Sulfate adenylyltransferase subunit 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3175230567
+UniRef50_Q4UY06: Sulfate adenylyltransferase subunit 2|g__Bacteroides.s__Bacteroides_stercoris	1.3123359580
+UniRef50_R5JSP7	2.6143790850
+UniRef50_R5JSP7|g__Bacteroides.s__Bacteroides_stercoris	2.6143790850
+UniRef50_R7P593	2.6041666667
+UniRef50_R7P593|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.6041666667
+UniRef50_R5WCH7: Transcriptional regulator AraC family	2.5940337224
+UniRef50_R5WCH7: Transcriptional regulator AraC family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5940337224
+UniRef50_Q5L9P4: Ribosome maturation factor RimM	2.5839793282
+UniRef50_Q5L9P4: Ribosome maturation factor RimM|g__Bacteroides.s__Bacteroides_stercoris	2.5839793282
+UniRef50_Q8AA15: Phosphomethylpyrimidine synthase	2.5839793282
+UniRef50_Q8AA15: Phosphomethylpyrimidine synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5839793282
+UniRef50_Q8ABT6: Transposase	2.5839793282
+UniRef50_Q8ABT6: Transposase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5839793282
+UniRef50_R5AL72	2.5839793282
+UniRef50_R5AL72|g__Bacteroides.s__Bacteroides_stercoris	2.5839793282
+UniRef50_R5F165	2.5839793282
+UniRef50_R5F165|g__Bacteroides.s__Bacteroides_stercoris	2.5839793282
+UniRef50_R6ARZ0	2.5839793282
+UniRef50_R6ARZ0|g__Bacteroides.s__Bacteroides_stercoris	2.5839793282
+UniRef50_R6AK47: Peptidase M16 inactive domain protein	2.5839793282
+UniRef50_R6AK47: Peptidase M16 inactive domain protein|g__Bacteroides.s__Bacteroides_stercoris	2.5839793282
+UniRef50_R7LCU5: Transcription elongation factor NusA	2.5641025641
+UniRef50_R7LCU5: Transcription elongation factor NusA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5641025641
+UniRef50_R7CVV2: Alpha-N-arabinofuranosidase	2.5641025641
+UniRef50_R7CVV2: Alpha-N-arabinofuranosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5641025641
+UniRef50_R6JDG7	2.5591810621
+UniRef50_R6JDG7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5591810621
+UniRef50_R5DDM9	2.5378261541
+UniRef50_R5DDM9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3123359580
+UniRef50_R5DDM9|g__Bacteroides.s__Bacteroides_stercoris	1.2254901961
+UniRef50_Q8A8P1: Mobilization protein BmgA	2.5354407377
+UniRef50_Q8A8P1: Mobilization protein BmgA|g__Bacteroides.s__Bacteroides_stercoris	1.2870012870
+UniRef50_Q8A8P1: Mobilization protein BmgA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_R5S2U5: Ribose-phosphate pyrophosphokinase	2.5348542459
+UniRef50_R5S2U5: Ribose-phosphate pyrophosphokinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5348542459
+UniRef50_D6D2H7: Relaxase/Mobilisation nuclease domain	2.5252525253
+UniRef50_D6D2H7: Relaxase/Mobilisation nuclease domain|g__Bacteroides.s__Bacteroides_stercoris	2.5252525253
+UniRef50_Q8AB84	2.5252525253
+UniRef50_Q8AB84|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5252525253
+UniRef50_A6KWE7: RNA polymerase ECF-type sigma factor	2.5062656642
+UniRef50_A6KWE7: RNA polymerase ECF-type sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5062656642
+UniRef50_R6STZ2: Sigma-70 region 2	2.5062656642
+UniRef50_R6STZ2: Sigma-70 region 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.5062656642
+UniRef50_R6JI98: Dihydrolipoyl dehydrogenase	2.5001243843
+UniRef50_R6JI98: Dihydrolipoyl dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6750418760
+UniRef50_R6JI98: Dihydrolipoyl dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	0.8250825083
+UniRef50_A6GZ94: 50S ribosomal protein L22	2.5000000000
+UniRef50_A6GZ94: 50S ribosomal protein L22|g__Bacteroides.s__Bacteroides_stercoris	2.5000000000
+UniRef50_R7ACY8: Dyp-type peroxidase	2.4968789014
+UniRef50_R7ACY8: Dyp-type peroxidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4968789014
+UniRef50_E6SVE9: GCN5-related N-acetyltransferase	2.4875621891
+UniRef50_E6SVE9: GCN5-related N-acetyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4875621891
+UniRef50_R6BST1: 2-oxoglutarate oxidoreductase gamma subunit	2.4875621891
+UniRef50_R6BST1: 2-oxoglutarate oxidoreductase gamma subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4875621891
+UniRef50_R6DHP0	2.4875621891
+UniRef50_R6DHP0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4875621891
+UniRef50_R6JH83	2.4875621891
+UniRef50_R6JH83|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4875621891
+UniRef50_R7E540	2.4875621891
+UniRef50_R7E540|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4875621891
+UniRef50_D5EYI2: Maltodextrin phosphorylase	2.4844720497
+UniRef50_D5EYI2: Maltodextrin phosphorylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6563146998
+UniRef50_D5EYI2: Maltodextrin phosphorylase|g__Bacteroides.s__Bacteroides_stercoris	0.8281573499
+UniRef50_F0R4F1: DNA topoisomerase	2.4794813435
+UniRef50_F0R4F1: DNA topoisomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8621973929
+UniRef50_F0R4F1: DNA topoisomerase|g__Bacteroides.s__Bacteroides_stercoris	0.6172839506
+UniRef50_Q5LJ70: tRNA-2-methylthio-N(6)-dimethylallyladenosine synthase	2.4630541872
+UniRef50_Q5LJ70: tRNA-2-methylthio-N(6)-dimethylallyladenosine synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6420361248
+UniRef50_Q5LJ70: tRNA-2-methylthio-N(6)-dimethylallyladenosine synthase|g__Bacteroides.s__Bacteroides_stercoris	0.8210180624
+UniRef50_B2RJD7: Translation initiation factor IF-3	2.4509803922
+UniRef50_B2RJD7: Translation initiation factor IF-3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4509803922
+UniRef50_Q8A8I0: Transcriptional regulator	2.4509803922
+UniRef50_Q8A8I0: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4509803922
+UniRef50_R6KQ62	2.4330900243
+UniRef50_R6KQ62|g__Bacteroides.s__Bacteroides_stercoris	2.4330900243
+UniRef50_R7KLA8	2.4295549634
+UniRef50_R7KLA8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5835312747
+UniRef50_R7KLA8|g__Bacteroides.s__Bacteroides_stercoris	0.8460236887
+UniRef50_D6D0X5: Translation factor SUA5	2.4154589372
+UniRef50_D6D0X5: Translation factor SUA5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4154589372
+UniRef50_R6ILE4	2.4154589372
+UniRef50_R6ILE4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.4154589372
+UniRef50_A7NLF0: Transport system permease protein	2.4067388688
+UniRef50_A7NLF0: Transport system permease protein|g__Bacteroides.s__Bacteroides_stercoris	1.2033694344
+UniRef50_A7NLF0: Transport system permease protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2033694344
+UniRef50_P26830: Putative peroxiredoxin in ndh 5'region (Fragment)	2.3980815348
+UniRef50_P26830: Putative peroxiredoxin in ndh 5'region (Fragment)|g__Bacteroides.s__Bacteroides_stercoris	2.3980815348
+UniRef50_R6E7T4: Glycosyltransferase group 4 family	2.3809523810
+UniRef50_R6E7T4: Glycosyltransferase group 4 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3809523810
+UniRef50_F0R4S9: Copper amine oxidase domain-containing protein	2.3724792408
+UniRef50_F0R4S9: Copper amine oxidase domain-containing protein|g__Bacteroides.s__Bacteroides_stercoris	2.3724792408
+UniRef50_Q2RKK1: Xanthine phosphoribosyltransferase	2.3640661939
+UniRef50_Q2RKK1: Xanthine phosphoribosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3640661939
+UniRef50_R6AZR7: Transcription termination/antitermination factor NusG	2.3640661939
+UniRef50_R6AZR7: Transcription termination/antitermination factor NusG|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3640661939
+UniRef50_R7CUN8: RNA polymerase ECF-type sigma factor	2.3640661939
+UniRef50_R7CUN8: RNA polymerase ECF-type sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3640661939
+UniRef50_R6VGJ6	2.3529411765
+UniRef50_R6VGJ6|g__Bacteroides.s__Bacteroides_stercoris	2.3529411765
+UniRef50_R7DIF4: NodT family efflux transporter outer membrane factor (OMF) lipoprotein	2.3516696482
+UniRef50_R7DIF4: NodT family efflux transporter outer membrane factor (OMF) lipoprotein|g__Bacteroides.s__Bacteroides_stercoris	1.5503875969
+UniRef50_R7DIF4: NodT family efflux transporter outer membrane factor (OMF) lipoprotein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8012820513
+UniRef50_G4QII0: D-isomer specific 2-hydroxyacid dehydrogenase, NAD-binding protein	2.3474178404
+UniRef50_G4QII0: D-isomer specific 2-hydroxyacid dehydrogenase, NAD-binding protein|g__Bacteroides.s__Bacteroides_stercoris	1.1737089202
+UniRef50_G4QII0: D-isomer specific 2-hydroxyacid dehydrogenase, NAD-binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1737089202
+UniRef50_R7ELF1	2.3310023310
+UniRef50_R7ELF1|g__Bacteroides.s__Bacteroides_stercoris	2.3310023310
+UniRef50_T2N9I9: Conjugative transposon TraJ protein	2.3269980507
+UniRef50_T2N9I9: Conjugative transposon TraJ protein|g__Bacteroides.s__Bacteroides_stercoris	1.1695906433
+UniRef50_T2N9I9: Conjugative transposon TraJ protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1574074074
+UniRef50_R7KL80	2.3228803717
+UniRef50_R7KL80|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3228803717
+UniRef50_R6L7C1: Bacterial transferase hexapeptide repeat protein	2.3148148148
+UniRef50_R6L7C1: Bacterial transferase hexapeptide repeat protein|g__Bacteroides.s__Bacteroides_stercoris	2.3148148148
+UniRef50_Q89ZT0: MscS mechanosensitive ion channel	2.3081592231
+UniRef50_Q89ZT0: MscS mechanosensitive ion channel|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.3081592231
+UniRef50_A7UZY6	2.2988505747
+UniRef50_A7UZY6|g__Bacteroides.s__Bacteroides_stercoris	2.2988505747
+UniRef50_R5JK49: Cyclic nucleotide-binding domain-containing protein	2.2988505747
+UniRef50_R5JK49: Cyclic nucleotide-binding domain-containing protein|g__Bacteroides.s__Bacteroides_stercoris	2.2988505747
+UniRef50_R5UR02	2.2988505747
+UniRef50_R5UR02|g__Bacteroides.s__Bacteroides_stercoris	2.2988505747
+UniRef50_R5VAH1	2.2988505747
+UniRef50_R5VAH1|g__Bacteroides.s__Bacteroides_stercoris	2.2988505747
+UniRef50_R7J8P5	2.2988505747
+UniRef50_R7J8P5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2988505747
+UniRef50_W0EU49: Molecular chaperone DnaJ	2.2831050228
+UniRef50_W0EU49: Molecular chaperone DnaJ|g__Bacteroides.s__Bacteroides_stercoris	2.2831050228
+UniRef50_F9D752	2.2675736961
+UniRef50_F9D752|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2675736961
+UniRef50_Q8A6Z7: RNA polymerase ECF-type sigma factor	2.2675736961
+UniRef50_Q8A6Z7: RNA polymerase ECF-type sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2675736961
+UniRef50_R5C4Q9	2.2675736961
+UniRef50_R5C4Q9|g__Bacteroides.s__Bacteroides_stercoris	2.2675736961
+UniRef50_A6L2I3: Phenylalanine--tRNA ligase alpha subunit	2.2611652223
+UniRef50_A6L2I3: Phenylalanine--tRNA ligase alpha subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1312217195
+UniRef50_A6L2I3: Phenylalanine--tRNA ligase alpha subunit|g__Bacteroides.s__Bacteroides_stercoris	1.1299435028
+UniRef50_R5CA64: Phosphate-selective porin O and P	2.2601207441
+UniRef50_R5CA64: Phosphate-selective porin O and P|g__Bacteroides.s__Bacteroides_stercoris	1.1415525114
+UniRef50_R5CA64: Phosphate-selective porin O and P|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1185682327
+UniRef50_R6LK37: Inosine-5'-monophosphate dehydrogenase	2.2528619174
+UniRef50_R6LK37: Inosine-5'-monophosphate dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	1.5004164697
+UniRef50_R6LK37: Inosine-5'-monophosphate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7524454477
+UniRef50_Q5LG55: 50S ribosomal protein L25	2.2522522523
+UniRef50_Q5LG55: 50S ribosomal protein L25|g__Bacteroides.s__Bacteroides_stercoris	2.2522522523
+UniRef50_B3EUK4: 50S ribosomal protein L15	2.2471910112
+UniRef50_B3EUK4: 50S ribosomal protein L15|g__Bacteroides.s__Bacteroides_stercoris	2.2471910112
+UniRef50_R5S0F4	2.2371364653
+UniRef50_R5S0F4|g__Bacteroides.s__Bacteroides_stercoris	2.2371364653
+UniRef50_P0A992: Fructose-bisphosphate aldolase class 1	2.2222222222
+UniRef50_P0A992: Fructose-bisphosphate aldolase class 1|g__Bacteroides.s__Bacteroides_stercoris	1.1111111111
+UniRef50_P0A992: Fructose-bisphosphate aldolase class 1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1111111111
+UniRef50_R5U9H7	2.2222222222
+UniRef50_R5U9H7|g__Bacteroides.s__Bacteroides_stercoris	2.2222222222
+UniRef50_R6JBG2: RNA polymerase ECF-type sigma factor	2.2075055188
+UniRef50_R6JBG2: RNA polymerase ECF-type sigma factor|g__Bacteroides.s__Bacteroides_stercoris	2.2075055188
+UniRef50_R6YIV5	2.2075055188
+UniRef50_R6YIV5|g__Bacteroides.s__Bacteroides_stercoris	2.2075055188
+UniRef50_P10172: Glutaminase-asparaginase	2.2002200220
+UniRef50_P10172: Glutaminase-asparaginase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.2002200220
+UniRef50_Q8A749: Maf-like protein BT_1676	2.1978021978
+UniRef50_Q8A749: Maf-like protein BT_1676|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1978021978
+UniRef50_A6KXG9: Adenylyl-sulfate kinase	2.1929824561
+UniRef50_A6KXG9: Adenylyl-sulfate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1929824561
+UniRef50_R6K7N0	2.1929824561
+UniRef50_R6K7N0|g__Bacteroides.s__Bacteroides_stercoris	2.1929824561
+UniRef50_R6WTW9	2.1929824561
+UniRef50_R6WTW9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1929824561
+UniRef50_R7EGB3	2.1929824561
+UniRef50_R7EGB3|g__Bacteroides.s__Bacteroides_stercoris	2.1929824561
+UniRef50_D4IL09: Transposase and inactivated derivatives	2.1880693142
+UniRef50_D4IL09: Transposase and inactivated derivatives|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1880693142
+UniRef50_B0NV90	2.1786492375
+UniRef50_B0NV90|g__Bacteroides.s__Bacteroides_stercoris	2.1786492375
+UniRef50_R5JKC4	2.1786492375
+UniRef50_R5JKC4|g__Bacteroides.s__Bacteroides_stercoris	2.1786492375
+UniRef50_R6D686: MgtC family protein	2.1786492375
+UniRef50_R6D686: MgtC family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1786492375
+UniRef50_R7KG28: PHP domain-containing protein	2.1715526602
+UniRef50_R7KG28: PHP domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1715526602
+UniRef50_F0R8Z2	2.1645021645
+UniRef50_F0R8Z2|g__Bacteroides.s__Bacteroides_stercoris	2.1645021645
+UniRef50_R5UXB6	2.1645021645
+UniRef50_R5UXB6|g__Bacteroides.s__Bacteroides_stercoris	2.1645021645
+UniRef50_Q7W4T6: Holliday junction ATP-dependent DNA helicase RuvB	2.1625934324
+UniRef50_Q7W4T6: Holliday junction ATP-dependent DNA helicase RuvB|g__Bacteroides.s__Bacteroides_stercoris	1.1337868481
+UniRef50_Q7W4T6: Holliday junction ATP-dependent DNA helicase RuvB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0288065844
+UniRef50_R5USW4	2.1505376344
+UniRef50_R5USW4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1505376344
+UniRef50_D2QJ16: Fumarylacetoacetate (FAA) hydrolase	2.1367521368
+UniRef50_D2QJ16: Fumarylacetoacetate (FAA) hydrolase|g__Bacteroides.s__Bacteroides_stercoris	2.1367521368
+UniRef50_F5J219	2.1367521368
+UniRef50_F5J219|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1367521368
+UniRef50_R5I8Z9	2.1367521368
+UniRef50_R5I8Z9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1367521368
+UniRef50_Q5LFT6: Aminomethyltransferase	2.1231422505
+UniRef50_Q5LFT6: Aminomethyltransferase|g__Bacteroides.s__Bacteroides_stercoris	2.1231422505
+UniRef50_R7JCR6	2.1231422505
+UniRef50_R7JCR6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1231422505
+UniRef50_R5ETA7: Arylsulfatase	2.1097233820
+UniRef50_R5ETA7: Arylsulfatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4094432699
+UniRef50_R5ETA7: Arylsulfatase|g__Bacteroides.s__Bacteroides_stercoris	0.7002801120
+UniRef50_R6JHE8: Efflux transporter RND family MFP subunit	2.1097046414
+UniRef50_R6JHE8: Efflux transporter RND family MFP subunit|g__Bacteroides.s__Bacteroides_stercoris	1.0548523207
+UniRef50_R6JHE8: Efflux transporter RND family MFP subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0548523207
+UniRef50_R5PE61	2.1063770315
+UniRef50_R5PE61|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.1063770315
+UniRef50_E6STF3: CDP-alcohol phosphatidyltransferase	2.0833333333
+UniRef50_E6STF3: CDP-alcohol phosphatidyltransferase|g__Bacteroides.s__Bacteroides_stercoris	2.0833333333
+UniRef50_Q8AA13: Thiamine-phosphate synthase	2.0833333333
+UniRef50_Q8AA13: Thiamine-phosphate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0833333333
+UniRef50_R7DMI0	2.0833333333
+UniRef50_R7DMI0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0833333333
+UniRef50_D6D0E8: Site-specific recombinase XerD	2.0768431983
+UniRef50_D6D0E8: Site-specific recombinase XerD|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0768431983
+UniRef50_A6L561: Transposase	2.0703933747
+UniRef50_A6L561: Transposase|g__Bacteroides.s__Bacteroides_stercoris	2.0703933747
+UniRef50_R7J8G7	2.0703933747
+UniRef50_R7J8G7|g__Bacteroides.s__Bacteroides_stercoris	2.0703933747
+UniRef50_F9Z3F4: Epidermal growth-factor receptor (EGFR) L domain	2.0607934055
+UniRef50_F9Z3F4: Epidermal growth-factor receptor (EGFR) L domain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5455950541
+UniRef50_F9Z3F4: Epidermal growth-factor receptor (EGFR) L domain|g__Bacteroides.s__Bacteroides_stercoris	0.5151983514
+UniRef50_R6PW67: Bacterial sugar transferase	2.0576131687
+UniRef50_R6PW67: Bacterial sugar transferase|g__Bacteroides.s__Bacteroides_stercoris	2.0576131687
+UniRef50_R6Z2N6	2.0576131687
+UniRef50_R6Z2N6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0576131687
+UniRef50_A6L3K9: DNA replication and repair protein RecF	2.0548378926
+UniRef50_A6L3K9: DNA replication and repair protein RecF|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0416666667
+UniRef50_A6L3K9: DNA replication and repair protein RecF|g__Bacteroides.s__Bacteroides_stercoris	1.0131712259
+UniRef50_Q5LI12: Orotate phosphoribosyltransferase	2.0449897751
+UniRef50_Q5LI12: Orotate phosphoribosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0449897751
+UniRef50_R6JGW7: Metallo-beta-lactamase domain protein	2.0449897751
+UniRef50_R6JGW7: Metallo-beta-lactamase domain protein|g__Bacteroides.s__Bacteroides_stercoris	2.0449897751
+UniRef50_R6JHB2	2.0449897751
+UniRef50_R6JHB2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0449897751
+UniRef50_R7E1I3	2.0449897751
+UniRef50_R7E1I3|g__Bacteroides.s__Bacteroides_stercoris	2.0449897751
+UniRef50_A4CN78: Queuine tRNA-ribosyltransferase	2.0387359837
+UniRef50_A4CN78: Queuine tRNA-ribosyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.0193679918
+UniRef50_A4CN78: Queuine tRNA-ribosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0193679918
+UniRef50_R5C552	2.0366598778
+UniRef50_R5C552|g__Bacteroides.s__Bacteroides_stercoris	2.0366598778
+UniRef50_Q5LFJ5: Pyridoxine/pyridoxamine 5'-phosphate oxidase	2.0325203252
+UniRef50_Q5LFJ5: Pyridoxine/pyridoxamine 5'-phosphate oxidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0325203252
+UniRef50_Q8A477: 50S ribosomal protein L4	2.0325203252
+UniRef50_Q8A477: 50S ribosomal protein L4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0325203252
+UniRef50_R6MDV7: Conserved domain protein	2.0325203252
+UniRef50_R6MDV7: Conserved domain protein|g__Bacteroides.s__Bacteroides_stercoris	2.0325203252
+UniRef50_R6AC71: Formiminotransferase-cyclodeaminase	2.0242914980
+UniRef50_R6AC71: Formiminotransferase-cyclodeaminase|g__Bacteroides.s__Bacteroides_stercoris	2.0242914980
+UniRef50_Q8A157: Putative endothelin-converting enzyme	2.0202020202
+UniRef50_Q8A157: Putative endothelin-converting enzyme|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0202020202
+UniRef50_R6S681	2.0202020202
+UniRef50_R6S681|g__Bacteroides.s__Bacteroides_thetaiotaomicron	2.0202020202
+UniRef50_C7MNW3: Acyl-CoA synthetase (AMP-forming)/AMP-acid ligase II	2.0026720107
+UniRef50_C7MNW3: Acyl-CoA synthetase (AMP-forming)/AMP-acid ligase II|g__Bacteroides.s__Bacteroides_stercoris	1.3360053440
+UniRef50_C7MNW3: Acyl-CoA synthetase (AMP-forming)/AMP-acid ligase II|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6666666667
+UniRef50_R6Y770: Ribulose-phosphate 3-epimerase	1.9960079840
+UniRef50_R6Y770: Ribulose-phosphate 3-epimerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9960079840
+UniRef50_A6LCK4: Galactokinase	1.9900497512
+UniRef50_A6LCK4: Galactokinase|g__Bacteroides.s__Bacteroides_stercoris	1.9900497512
+UniRef50_B7UZU0: Na(+)-translocating NADH-quinone reductase subunit D	1.9841269841
+UniRef50_B7UZU0: Na(+)-translocating NADH-quinone reductase subunit D|g__Bacteroides.s__Bacteroides_stercoris	1.9841269841
+UniRef50_R5W7K3	1.9841269841
+UniRef50_R5W7K3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9841269841
+UniRef50_R6JEH2: CDP-diacylglycerol-glycerol-3-phosphate 3-phosphatidyltransferase-related protein	1.9841269841
+UniRef50_R6JEH2: CDP-diacylglycerol-glycerol-3-phosphate 3-phosphatidyltransferase-related protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9841269841
+UniRef50_R5GVY8	1.9782567859
+UniRef50_R5GVY8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9920634921
+UniRef50_R5GVY8|g__Bacteroides.s__Bacteroides_stercoris	0.9861932939
+UniRef50_Q8A800: Diaminopimelate decarboxylase	1.9782393670
+UniRef50_Q8A800: Diaminopimelate decarboxylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9782393670
+UniRef50_T2KQD4: Na+-transporting methylmalonyl-CoA/oxaloacetate decarboxylase, beta subunit	1.9782393670
+UniRef50_T2KQD4: Na+-transporting methylmalonyl-CoA/oxaloacetate decarboxylase, beta subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9782393670
+UniRef50_Q7MWN8	1.9775890633
+UniRef50_Q7MWN8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3175230567
+UniRef50_Q7MWN8|g__Bacteroides.s__Bacteroides_stercoris	0.6600660066
+UniRef50_Q11SW8: Lipoprotein-releasing system ATP-binding protein LolD	1.9723865878
+UniRef50_Q11SW8: Lipoprotein-releasing system ATP-binding protein LolD|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9723865878
+UniRef50_R7CWN7: WbqC-like protein	1.9723865878
+UniRef50_R7CWN7: WbqC-like protein|g__Bacteroides.s__Bacteroides_stercoris	1.9723865878
+UniRef50_G8UL57: ATP-dependent DNA helicase RecQ	1.9680207521
+UniRef50_G8UL57: ATP-dependent DNA helicase RecQ|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9847365830
+UniRef50_G8UL57: ATP-dependent DNA helicase RecQ|g__Bacteroides.s__Bacteroides_stercoris	0.9832841691
+UniRef50_R6HYK5: N-acetylglucosamine-6-phosphate deacetylase	1.9665683382
+UniRef50_R6HYK5: N-acetylglucosamine-6-phosphate deacetylase|g__Bacteroides.s__Bacteroides_stercoris	0.9832841691
+UniRef50_R6HYK5: N-acetylglucosamine-6-phosphate deacetylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9832841691
+UniRef50_R6FG07: Transposase IS4 family	1.9637104004
+UniRef50_R6FG07: Transposase IS4 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9861932939
+UniRef50_R6FG07: Transposase IS4 family|g__Bacteroides.s__Bacteroides_stercoris	0.9775171065
+UniRef50_Q8A861: L-Ala-D/L-Glu epimerase	1.9613951288
+UniRef50_Q8A861: L-Ala-D/L-Glu epimerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9980039920
+UniRef50_Q8A861: L-Ala-D/L-Glu epimerase|g__Bacteroides.s__Bacteroides_stercoris	0.9633911368
+UniRef50_B0NU13: Glycosyltransferase, group 1 family protein	1.9607843137
+UniRef50_B0NU13: Glycosyltransferase, group 1 family protein|g__Bacteroides.s__Bacteroides_stercoris	1.9607843137
+UniRef50_B5F621: Mannonate dehydratase	1.9607843137
+UniRef50_B5F621: Mannonate dehydratase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9607843137
+UniRef50_UPI000468D029: glutamine synthetase	1.9607843137
+UniRef50_UPI000468D029: glutamine synthetase|g__Bacteroides.s__Bacteroides_stercoris	0.9803921569
+UniRef50_UPI000468D029: glutamine synthetase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9803921569
+UniRef50_R5AN19: NADH:ubiquinone oxidoreductase Na(+)-translocating B subunit	1.9550342131
+UniRef50_R5AN19: NADH:ubiquinone oxidoreductase Na(+)-translocating B subunit|g__Bacteroides.s__Bacteroides_stercoris	1.9550342131
+UniRef50_R6B574: Glycosyltransferase group 2 family protein	1.9550342131
+UniRef50_R6B574: Glycosyltransferase group 2 family protein|g__Bacteroides.s__Bacteroides_stercoris	1.9550342131
+UniRef50_A6LG36: Renin-binding protein-related protein	1.9493177388
+UniRef50_A6LG36: Renin-binding protein-related protein|g__Bacteroides.s__Bacteroides_stercoris	1.9493177388
+UniRef50_Q182G9: Uracil-DNA glycosylase	1.9493177388
+UniRef50_Q182G9: Uracil-DNA glycosylase|g__Bacteroides.s__Bacteroides_stercoris	1.9493177388
+UniRef50_R6E9G2: Phosphoenolpyruvate synthase	1.9447685725
+UniRef50_R6E9G2: Phosphoenolpyruvate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1668611435
+UniRef50_R6E9G2: Phosphoenolpyruvate synthase|g__Bacteroides.s__Bacteroides_stercoris	0.7779074290
+UniRef50_P0CJ82	1.9417475728
+UniRef50_P0CJ82|g__Bacteroides.s__Bacteroides_stercoris	1.2944983819
+UniRef50_P0CJ82|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6472491909
+UniRef50_F0R5I4	1.9267822736
+UniRef50_F0R5I4|g__Bacteroides.s__Bacteroides_stercoris	1.9267822736
+UniRef50_Q8ABT9	1.9267822736
+UniRef50_Q8ABT9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9267822736
+UniRef50_Q8ABV6	1.9267822736
+UniRef50_Q8ABV6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9267822736
+UniRef50_R5JVY0	1.9267822736
+UniRef50_R5JVY0|g__Bacteroides.s__Bacteroides_stercoris	1.9267822736
+UniRef50_E4T3Y0: Flavodoxin/nitric oxide synthase	1.9102196753
+UniRef50_E4T3Y0: Flavodoxin/nitric oxide synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9102196753
+UniRef50_Q5LI41: Acetate kinase	1.9102196753
+UniRef50_Q5LI41: Acetate kinase|g__Bacteroides.s__Bacteroides_stercoris	1.9102196753
+UniRef50_E4TAG3: Ribosomal RNA small subunit methyltransferase I	1.9047619048
+UniRef50_E4TAG3: Ribosomal RNA small subunit methyltransferase I|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9047619048
+UniRef50_Q8A1G8: Acetate kinase	1.9047619048
+UniRef50_Q8A1G8: Acetate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.9047619048
+UniRef50_L0G4L7: Response regulator with CheY-like receiver domain and winged-helix DNA-binding domain	1.8939393939
+UniRef50_L0G4L7: Response regulator with CheY-like receiver domain and winged-helix DNA-binding domain|g__Bacteroides.s__Bacteroides_stercoris	1.8939393939
+UniRef50_R5Y5R7: Nucleotide sugar dehydrogenase	1.8939393939
+UniRef50_R5Y5R7: Nucleotide sugar dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	1.8939393939
+UniRef50_I4AQY4: Argininosuccinate synthase	1.8885741265
+UniRef50_I4AQY4: Argininosuccinate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8885741265
+UniRef50_A6LGY9: Mobilization protein BmgB	1.8761726079
+UniRef50_A6LGY9: Mobilization protein BmgB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8761726079
+UniRef50_R5GDB8: Radical SAM protein TIGR01212 family	1.8726591760
+UniRef50_R5GDB8: Radical SAM protein TIGR01212 family|g__Bacteroides.s__Bacteroides_stercoris	1.8726591760
+UniRef50_A6LCF8: Glycoside hydrolase family 92	1.8682795076
+UniRef50_A6LCF8: Glycoside hydrolase family 92|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9389969397
+UniRef50_A6LCF8: Glycoside hydrolase family 92|g__Bacteroides.s__Bacteroides_stercoris	0.9292825680
+UniRef50_E6SSG1: Outer membrane efflux protein	1.8674136321
+UniRef50_E6SSG1: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8674136321
+UniRef50_F0S6F8: Glycosyl hydrolase family 88	1.8674136321
+UniRef50_F0S6F8: Glycosyl hydrolase family 88|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8674136321
+UniRef50_D6D8P2: Outer membrane transport energization protein TonB (TC 2.C.1.1.1)	1.8621973929
+UniRef50_D6D8P2: Outer membrane transport energization protein TonB (TC 2.C.1.1.1)|g__Bacteroides.s__Bacteroides_stercoris	1.8621973929
+UniRef50_Q5L9K4: Cytidylate kinase	1.8518518519
+UniRef50_Q5L9K4: Cytidylate kinase|g__Bacteroides.s__Bacteroides_stercoris	1.8518518519
+UniRef50_Q8A501: Integrase	1.8518518519
+UniRef50_Q8A501: Integrase|g__Bacteroides.s__Bacteroides_stercoris	0.9259259259
+UniRef50_Q8A501: Integrase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9259259259
+UniRef50_R5JDA3: Hemolysin III family channel protein	1.8518518519
+UniRef50_R5JDA3: Hemolysin III family channel protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8518518519
+UniRef50_A6LB33: Haloacid dehalogenase-like hydrolase	1.8467220683
+UniRef50_A6LB33: Haloacid dehalogenase-like hydrolase|g__Bacteroides.s__Bacteroides_stercoris	0.9233610342
+UniRef50_A6LB33: Haloacid dehalogenase-like hydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9233610342
+UniRef50_R6RVA2	1.8467220683
+UniRef50_R6RVA2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8467220683
+UniRef50_A6L6L6: Tyrosine type site-specific recombinase	1.8416206262
+UniRef50_A6L6L6: Tyrosine type site-specific recombinase|g__Bacteroides.s__Bacteroides_stercoris	1.8416206262
+UniRef50_R7EGW5	1.8416206262
+UniRef50_R7EGW5|g__Bacteroides.s__Bacteroides_stercoris	1.8416206262
+UniRef50_R5EV05	1.8382352941
+UniRef50_R5EV05|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8382352941
+UniRef50_Q64WK8	1.8365472911
+UniRef50_Q64WK8|g__Bacteroides.s__Bacteroides_stercoris	0.9182736455
+UniRef50_Q64WK8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9182736455
+UniRef50_A6LH06: Transposase	1.8315571255
+UniRef50_A6LH06: Transposase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9208103131
+UniRef50_A6LH06: Transposase|g__Bacteroides.s__Bacteroides_stercoris	0.9107468124
+UniRef50_Q8A8H3: Outer membrane protein, OmpA family	1.8315018315
+UniRef50_Q8A8H3: Outer membrane protein, OmpA family|g__Bacteroides.s__Bacteroides_stercoris	1.8315018315
+UniRef50_R6JGH9: Flavodoxin-like protein	1.8315018315
+UniRef50_R6JGH9: Flavodoxin-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8315018315
+UniRef50_A1SEI7: 50S ribosomal protein L1	1.8214936248
+UniRef50_A1SEI7: 50S ribosomal protein L1|g__Bacteroides.s__Bacteroides_stercoris	1.8214936248
+UniRef50_I9A722	1.8214936248
+UniRef50_I9A722|g__Bacteroides.s__Bacteroides_stercoris	1.8214936248
+UniRef50_A6L0J2	1.8115942029
+UniRef50_A6L0J2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8115942029
+UniRef50_Q9AE24: Transcriptional regulatory protein RprY	1.8115942029
+UniRef50_Q9AE24: Transcriptional regulatory protein RprY|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8115942029
+UniRef50_R5P0L2	1.8115942029
+UniRef50_R5P0L2|g__Bacteroides.s__Bacteroides_stercoris	1.8115942029
+UniRef50_R6ADR4: PHP domain protein	1.8115942029
+UniRef50_R6ADR4: PHP domain protein|g__Bacteroides.s__Bacteroides_stercoris	1.8115942029
+UniRef50_R6X7L9	1.8115942029
+UniRef50_R6X7L9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8115942029
+UniRef50_F2KXD1: Chromate transport protein	1.8018018018
+UniRef50_F2KXD1: Chromate transport protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8018018018
+UniRef50_R5AUC0: Succinate dehydrogenase cytochrome B subunit b558 family	1.8018018018
+UniRef50_R5AUC0: Succinate dehydrogenase cytochrome B subunit b558 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8018018018
+UniRef50_R5KU63	1.8018018018
+UniRef50_R5KU63|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.8018018018
+UniRef50_R6JE33	1.7969451932
+UniRef50_R6JE33|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7969451932
+UniRef50_R6YJT2: Glycosyl transferase group 1 family	1.7921146953
+UniRef50_R6YJT2: Glycosyl transferase group 1 family|g__Bacteroides.s__Bacteroides_stercoris	1.7921146953
+UniRef50_Q2S6J2: Uridylate kinase	1.7825311943
+UniRef50_Q2S6J2: Uridylate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7825311943
+UniRef50_R6UWR2	1.7825311943
+UniRef50_R6UWR2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7825311943
+UniRef50_R7CUQ3	1.7801544860
+UniRef50_R7CUQ3|g__Bacteroides.s__Bacteroides_stercoris	1.7801544860
+UniRef50_R6JP42: Outer membrane efflux protein	1.7777777778
+UniRef50_R6JP42: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7777777778
+UniRef50_R6FEU3: Chloramphenicol O-acetyltransferase	1.7730496454
+UniRef50_R6FEU3: Chloramphenicol O-acetyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.7730496454
+UniRef50_R6L4U7: Lipoyltransferase and lipoate-protein ligase	1.7543859649
+UniRef50_R6L4U7: Lipoyltransferase and lipoate-protein ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7543859649
+UniRef50_H6KZK2: Na(+)-translocating NADH-quinone reductase subunit F	1.7505530783
+UniRef50_H6KZK2: Na(+)-translocating NADH-quinone reductase subunit F|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8936550492
+UniRef50_H6KZK2: Na(+)-translocating NADH-quinone reductase subunit F|g__Bacteroides.s__Bacteroides_stercoris	0.8568980291
+UniRef50_Q650K7: Tyrosine--tRNA ligase	1.7497812773
+UniRef50_Q650K7: Tyrosine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.8748906387
+UniRef50_Q650K7: Tyrosine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8748906387
+UniRef50_E1WW45	1.7452006981
+UniRef50_E1WW45|g__Bacteroides.s__Bacteroides_stercoris	1.7452006981
+UniRef50_Q89YL2	1.7452006981
+UniRef50_Q89YL2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7452006981
+UniRef50_Q8A1W5	1.7452006981
+UniRef50_Q8A1W5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7452006981
+UniRef50_E6SUV1: Two component transcriptional regulator, winged helix family	1.7361111111
+UniRef50_E6SUV1: Two component transcriptional regulator, winged helix family|g__Bacteroides.s__Bacteroides_stercoris	1.7361111111
+UniRef50_Q89ZD6: Cell surface protein	1.7361111111
+UniRef50_Q89ZD6: Cell surface protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7361111111
+UniRef50_R5W193	1.7339971679
+UniRef50_R5W193|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8748906387
+UniRef50_R5W193|g__Bacteroides.s__Bacteroides_stercoris	0.8591065292
+UniRef50_R6DZB6	1.7271157168
+UniRef50_R6DZB6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7271157168
+UniRef50_B2RK67: UDP-glucose 6-dehydrogenase	1.7182130584
+UniRef50_B2RK67: UDP-glucose 6-dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7182130584
+UniRef50_Q11QB8: 30S ribosomal protein S3	1.7182130584
+UniRef50_Q11QB8: 30S ribosomal protein S3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7182130584
+UniRef50_I5ASD1: Nucleotide sugar dehydrogenase	1.7137960583
+UniRef50_I5ASD1: Nucleotide sugar dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7137960583
+UniRef50_R6RWK6: Beta-galactosidase	1.7097613428
+UniRef50_R6RWK6: Beta-galactosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0277492292
+UniRef50_R6RWK6: Beta-galactosidase|g__Bacteroides.s__Bacteroides_stercoris	0.6820121137
+UniRef50_R6SCN0	1.7094017094
+UniRef50_R6SCN0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7094017094
+UniRef50_E1WRZ6	1.7050298380
+UniRef50_E1WRZ6|g__Bacteroides.s__Bacteroides_stercoris	1.7050298380
+UniRef50_R6TIJ6: Signal recognition particle protein	1.7050298380
+UniRef50_R6TIJ6: Signal recognition particle protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7050298380
+UniRef50_A5FGS7: Probable transcriptional regulatory protein Fjoh_2560	1.7006802721
+UniRef50_A5FGS7: Probable transcriptional regulatory protein Fjoh_2560|g__Bacteroides.s__Bacteroides_stercoris	1.7006802721
+UniRef50_F4KLR9: H+transporting two-sector ATPase alpha/beta subunit central region	1.7006802721
+UniRef50_F4KLR9: H+transporting two-sector ATPase alpha/beta subunit central region|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7006802721
+UniRef50_R6B8H9	1.7006802721
+UniRef50_R6B8H9|g__Bacteroides.s__Bacteroides_stercoris	1.7006802721
+UniRef50_R7NWG3	1.7006802721
+UniRef50_R7NWG3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.7006802721
+UniRef50_Q8A4L0: Type I restriction enzyme, M subunit	1.6920473773
+UniRef50_Q8A4L0: Type I restriction enzyme, M subunit|g__Bacteroides.s__Bacteroides_stercoris	1.6920473773
+UniRef50_P70882: Tetracycline resistance protein TetQ	1.6891891892
+UniRef50_P70882: Tetracycline resistance protein TetQ|g__Bacteroides.s__Bacteroides_stercoris	1.6891891892
+UniRef50_R5VD83	1.6870521769
+UniRef50_R5VD83|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8438818565
+UniRef50_R5VD83|g__Bacteroides.s__Bacteroides_stercoris	0.8431703204
+UniRef50_B2RKJ1: NAD-specific glutamate dehydrogenase	1.6856326983
+UniRef50_B2RKJ1: NAD-specific glutamate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6856326983
+UniRef50_D3IEN1	1.6835016835
+UniRef50_D3IEN1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6835016835
+UniRef50_R7E0R5: Polygalacturonase (Pectinase)	1.6835016835
+UniRef50_R7E0R5: Polygalacturonase (Pectinase)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6835016835
+UniRef50_R6FFL5: Hydrogenase accessory protein HypB	1.6778523490
+UniRef50_R6FFL5: Hydrogenase accessory protein HypB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6778523490
+UniRef50_A6L0Q5	1.6750418760
+UniRef50_A6L0Q5|g__Bacteroides.s__Bacteroides_stercoris	1.6750418760
+UniRef50_B0NU15: Polysaccharide biosynthesis protein	1.6750418760
+UniRef50_B0NU15: Polysaccharide biosynthesis protein|g__Bacteroides.s__Bacteroides_stercoris	1.6750418760
+UniRef50_Q5HGK2: 3-oxoacyl-[acyl-carrier-protein] reductase FabG	1.6750418760
+UniRef50_Q5HGK2: 3-oxoacyl-[acyl-carrier-protein] reductase FabG|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6750418760
+UniRef50_R5UGF8: PP-loop domain protein	1.6750418760
+UniRef50_R5UGF8: PP-loop domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6750418760
+UniRef50_R7DML6: Biotin--[acetyl-CoA-carboxylase] ligase	1.6750418760
+UniRef50_R7DML6: Biotin--[acetyl-CoA-carboxylase] ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6750418760
+UniRef50_R6KCY7: Transporter major facilitator family protein	1.6708437761
+UniRef50_R6KCY7: Transporter major facilitator family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6708437761
+UniRef50_B0NLL8	1.6666666667
+UniRef50_B0NLL8|g__Bacteroides.s__Bacteroides_stercoris	1.6666666667
+UniRef50_E1WWH6: Na(+)-translocating NADH-quinone reductase subunit A	1.6666666667
+UniRef50_E1WWH6: Na(+)-translocating NADH-quinone reductase subunit A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6666666667
+UniRef50_F0R3R2	1.6666666667
+UniRef50_F0R3R2|g__Bacteroides.s__Bacteroides_stercoris	1.6666666667
+UniRef50_Q8A8Y1: Coagulation factor 5/8 type, C-terminal	1.6666666667
+UniRef50_Q8A8Y1: Coagulation factor 5/8 type, C-terminal|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6666666667
+UniRef50_R5J848	1.6666666667
+UniRef50_R5J848|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6666666667
+UniRef50_J9R6J8: Acetylornithine deacetylase/Succinyl-diaminopimelate desuccinylase-related deacylase	1.6543004628
+UniRef50_J9R6J8: Acetylornithine deacetylase/Succinyl-diaminopimelate desuccinylase-related deacylase|g__Bacteroides.s__Bacteroides_stercoris	0.8312551953
+UniRef50_J9R6J8: Acetylornithine deacetylase/Succinyl-diaminopimelate desuccinylase-related deacylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8230452675
+UniRef50_R6K575	1.6542597188
+UniRef50_R6K575|g__Bacteroides.s__Bacteroides_stercoris	1.6542597188
+UniRef50_R6DIB1: Hydrolase NUDIX family	1.6501650165
+UniRef50_R6DIB1: Hydrolase NUDIX family|g__Bacteroides.s__Bacteroides_stercoris	1.6501650165
+UniRef50_L0G144	1.6481277757
+UniRef50_L0G144|g__Bacteroides.s__Bacteroides_stercoris	0.8250825083
+UniRef50_L0G144|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8230452675
+UniRef50_R6XGT6	1.6434218120
+UniRef50_R6XGT6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6434218120
+UniRef50_B5YGT5: 3-deoxy-manno-octulosonate cytidylyltransferase	1.6420361248
+UniRef50_B5YGT5: 3-deoxy-manno-octulosonate cytidylyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.6420361248
+UniRef50_Q64ZY8: Outer membrane protein oprM	1.6420361248
+UniRef50_Q64ZY8: Outer membrane protein oprM|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6420361248
+UniRef50_R5M8E0	1.6420361248
+UniRef50_R5M8E0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6420361248
+UniRef50_R6RT73: Triosephosphate isomerase	1.6420361248
+UniRef50_R6RT73: Triosephosphate isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6420361248
+UniRef50_R6XM86: DNA repair protein radA	1.6420361248
+UniRef50_R6XM86: DNA repair protein radA|g__Bacteroides.s__Bacteroides_stercoris	1.6420361248
+UniRef50_W4PR50: DNA-directed RNA polymerase beta subunit	1.6380016380
+UniRef50_W4PR50: DNA-directed RNA polymerase beta subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6380016380
+UniRef50_Q11UF9: Peptidyl-prolyl cis-trans isomerase	1.6339869281
+UniRef50_Q11UF9: Peptidyl-prolyl cis-trans isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6339869281
+UniRef50_A8LC56: 50S ribosomal protein L3	1.6260162602
+UniRef50_A8LC56: 50S ribosomal protein L3|g__Bacteroides.s__Bacteroides_stercoris	1.6260162602
+UniRef50_C7N794: 2-oxoacid:ferredoxin oxidoreductase, beta subunit	1.6260162602
+UniRef50_C7N794: 2-oxoacid:ferredoxin oxidoreductase, beta subunit|g__Bacteroides.s__Bacteroides_stercoris	1.6260162602
+UniRef50_R6CKA3	1.6260162602
+UniRef50_R6CKA3|g__Bacteroides.s__Bacteroides_stercoris	1.6260162602
+UniRef50_R7PDU2: DNA ligase	1.6233766234
+UniRef50_R7PDU2: DNA ligase|g__Bacteroides.s__Bacteroides_stercoris	1.6233766234
+UniRef50_I0K5J6: Phosphomannomutase	1.6142050040
+UniRef50_I0K5J6: Phosphomannomutase|g__Bacteroides.s__Bacteroides_stercoris	0.8071025020
+UniRef50_I0K5J6: Phosphomannomutase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_C9MMK5	1.6129032258
+UniRef50_C9MMK5|g__Bacteroides.s__Bacteroides_stercoris	1.6129032258
+UniRef50_R6M7Y6: Transketolase thiamine diphosphate binding domain protein	1.6129032258
+UniRef50_R6M7Y6: Transketolase thiamine diphosphate binding domain protein|g__Bacteroides.s__Bacteroides_stercoris	1.0752688172
+UniRef50_R6M7Y6: Transketolase thiamine diphosphate binding domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5376344086
+UniRef50_A7ALL4	1.6103059581
+UniRef50_A7ALL4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6103059581
+UniRef50_B0NT38	1.6103059581
+UniRef50_B0NT38|g__Bacteroides.s__Bacteroides_stercoris	1.6103059581
+UniRef50_F0R1H7	1.6103059581
+UniRef50_F0R1H7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6103059581
+UniRef50_R6L8N8: Arylsulfatase	1.6103059581
+UniRef50_R6L8N8: Arylsulfatase|g__Bacteroides.s__Bacteroides_stercoris	1.6103059581
+UniRef50_A5FFH5: Bacteroides conjugative transposon MobC/BfmC-like protein	1.6026949775
+UniRef50_A5FFH5: Bacteroides conjugative transposon MobC/BfmC-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0650605689
+UniRef50_A5FFH5: Bacteroides conjugative transposon MobC/BfmC-like protein|g__Bacteroides.s__Bacteroides_stercoris	0.5376344086
+UniRef50_B0NLB3	1.6025641026
+UniRef50_B0NLB3|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_E6X4I7: Acetylglutamate kinase	1.6025641026
+UniRef50_E6X4I7: Acetylglutamate kinase|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_F0R8Y7	1.6025641026
+UniRef50_F0R8Y7|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_Q11QI8: Acetylglutamate kinase	1.6025641026
+UniRef50_Q11QI8: Acetylglutamate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6025641026
+UniRef50_R5AV72: MFS family major facilitator transporter glycerol-3-phosphate:cation symporter	1.6025641026
+UniRef50_R5AV72: MFS family major facilitator transporter glycerol-3-phosphate:cation symporter|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_R5F938: Radical SAM domain protein	1.6025641026
+UniRef50_R5F938: Radical SAM domain protein|g__Bacteroides.s__Bacteroides_stercoris	1.6025641026
+UniRef50_R6ZV72	1.6025641026
+UniRef50_R6ZV72|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.6025641026
+UniRef50_R5JTT9	1.5948963317
+UniRef50_R5JTT9|g__Bacteroides.s__Bacteroides_stercoris	1.5948963317
+UniRef50_R6DS19	1.5948963317
+UniRef50_R6DS19|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5948963317
+UniRef50_R7GYR7: Acyl-[acyl-carrier-protein]-UDP-N-acetylglucosami ne O-acyltransferase	1.5948963317
+UniRef50_R7GYR7: Acyl-[acyl-carrier-protein]-UDP-N-acetylglucosami ne O-acyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.5948963317
+UniRef50_B5F623: Uronate isomerase	1.5910898966
+UniRef50_B5F623: Uronate isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5910898966
+UniRef50_UPI000470128B: antitermination protein NusB	1.5797788310
+UniRef50_UPI000470128B: antitermination protein NusB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5797788310
+UniRef50_Q5LDR8	1.5649452269
+UniRef50_Q5LDR8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5649452269
+UniRef50_R6LDX1: ADP-ribosylglycohydrolase	1.5649452269
+UniRef50_R6LDX1: ADP-ribosylglycohydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5649452269
+UniRef50_R6CUQ3: ABC transporter	1.5612802498
+UniRef50_R6CUQ3: ABC transporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5612802498
+UniRef50_Q8A4F0: ThiF family protein, ubiquitin-activating enzyme	1.5576323988
+UniRef50_Q8A4F0: ThiF family protein, ubiquitin-activating enzyme|g__Bacteroides.s__Bacteroides_stercoris	1.5576323988
+UniRef50_R6BPS6: Putrescine transport system permease potI	1.5576323988
+UniRef50_R6BPS6: Putrescine transport system permease potI|g__Bacteroides.s__Bacteroides_stercoris	1.5576323988
+UniRef50_Q7UID0: Thymidylate synthase	1.5503875969
+UniRef50_Q7UID0: Thymidylate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5503875969
+UniRef50_R6JDJ4: Transcription termination factor Rho	1.5475596821
+UniRef50_R6JDJ4: Transcription termination factor Rho|g__Bacteroides.s__Bacteroides_stercoris	1.0522649817
+UniRef50_R6JDJ4: Transcription termination factor Rho|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4952947003
+UniRef50_B0NLK5	1.5432098765
+UniRef50_B0NLK5|g__Bacteroides.s__Bacteroides_stercoris	1.5432098765
+UniRef50_F4KXT8: Methionine aminopeptidase	1.5432098765
+UniRef50_F4KXT8: Methionine aminopeptidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5432098765
+UniRef50_Q8AAD8: Tryptophan synthase alpha chain	1.5432098765
+UniRef50_Q8AAD8: Tryptophan synthase alpha chain|g__Bacteroides.s__Bacteroides_stercoris	1.5432098765
+UniRef50_R7J3N7	1.5360983103
+UniRef50_R7J3N7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5360983103
+UniRef50_A6L1N4: Ribosomal RNA small subunit methyltransferase A	1.5290519878
+UniRef50_A6L1N4: Ribosomal RNA small subunit methyltransferase A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_B6YS11: Diaminopimelate epimerase	1.5290519878
+UniRef50_B6YS11: Diaminopimelate epimerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_F0R149: Beta-lactamase domain protein	1.5290519878
+UniRef50_F0R149: Beta-lactamase domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_Q8A041: Acetyl xylan esterase A	1.5290519878
+UniRef50_Q8A041: Acetyl xylan esterase A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_Q8A1A3: Rhamnulokinase	1.5290519878
+UniRef50_Q8A1A3: Rhamnulokinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_Q8A4L1	1.5290519878
+UniRef50_Q8A4L1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_Q8AAP9: Sulfate adenylyltransferase subunit 1	1.5290519878
+UniRef50_Q8AAP9: Sulfate adenylyltransferase subunit 1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_R5U735	1.5290519878
+UniRef50_R5U735|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5290519878
+UniRef50_R7KGK8	1.5263522800
+UniRef50_R7KGK8|g__Bacteroides.s__Bacteroides_stercoris	0.7806401249
+UniRef50_R7KGK8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7457121551
+UniRef50_R7KG97: Tetratricopeptide repeat family protein	1.5186028853
+UniRef50_R7KG97: Tetratricopeptide repeat family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5186028853
+UniRef50_R7KRY3	1.5186028853
+UniRef50_R7KRY3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5186028853
+UniRef50_E6SPF4: Sulfatase	1.5151515152
+UniRef50_E6SPF4: Sulfatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5151515152
+UniRef50_G8UMG2: ABC 3 transport family protein	1.5151515152
+UniRef50_G8UMG2: ABC 3 transport family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5151515152
+UniRef50_Q8A1A0: Rhamnulose-1-phosphate aldolase	1.5151515152
+UniRef50_Q8A1A0: Rhamnulose-1-phosphate aldolase|g__Bacteroides.s__Bacteroides_stercoris	1.5151515152
+UniRef50_R6J682	1.5151515152
+UniRef50_R6J682|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5151515152
+UniRef50_R6LC65: Phospholipase patatin family	1.5151515152
+UniRef50_R6LC65: Phospholipase patatin family|g__Bacteroides.s__Bacteroides_stercoris	1.5151515152
+UniRef50_B2RIW6: Polyribonucleotide nucleotidyltransferase	1.5113839135
+UniRef50_B2RIW6: Polyribonucleotide nucleotidyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0116337886
+UniRef50_B2RIW6: Polyribonucleotide nucleotidyltransferase|g__Bacteroides.s__Bacteroides_stercoris	0.4997501249
+UniRef50_Q64P75: TonB-like protein	1.5082956259
+UniRef50_Q64P75: TonB-like protein|g__Bacteroides.s__Bacteroides_stercoris	1.5082956259
+UniRef50_R5C323: Phosphate binding protein	1.5082956259
+UniRef50_R5C323: Phosphate binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5082956259
+UniRef50_Q11PK9: Cysteine--tRNA ligase	1.5048985637
+UniRef50_Q11PK9: Cysteine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.7541478130
+UniRef50_Q11PK9: Cysteine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7507507508
+UniRef50_A2U077: Methylmalonyl-CoA mutase large subunit	1.5015015015
+UniRef50_A2U077: Methylmalonyl-CoA mutase large subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0010010010
+UniRef50_A2U077: Methylmalonyl-CoA mutase large subunit|g__Bacteroides.s__Bacteroides_stercoris	0.5005005005
+UniRef50_Q8A869	1.5015015015
+UniRef50_Q8A869|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.5015015015
+UniRef50_R5RH80: TPR-repeat-containing protein	1.4947683109
+UniRef50_R5RH80: TPR-repeat-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4947683109
+UniRef50_A6LDN1: 2-isopropylmalate synthase	1.4914243102
+UniRef50_A6LDN1: 2-isopropylmalate synthase|g__Bacteroides.s__Bacteroides_stercoris	1.4914243102
+UniRef50_Q5LF90	1.4880952381
+UniRef50_Q5LF90|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4880952381
+UniRef50_B1ZNE5: 50S ribosomal protein L2	1.4814814815
+UniRef50_B1ZNE5: 50S ribosomal protein L2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4814814815
+UniRef50_Q64VH8: ROK family transcriptional repressor	1.4814814815
+UniRef50_Q64VH8: ROK family transcriptional repressor|g__Bacteroides.s__Bacteroides_stercoris	1.4814814815
+UniRef50_R5EPQ9: Sec-independent protein translocase protein TatC	1.4814814815
+UniRef50_R5EPQ9: Sec-independent protein translocase protein TatC|g__Bacteroides.s__Bacteroides_stercoris	1.4814814815
+UniRef50_H1YF07: Endonuclease III	1.4792899408
+UniRef50_H1YF07: Endonuclease III|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4792899408
+UniRef50_Q2RZU6: tRNA nucleotidyltransferase/poly(A) polymerase family protein	1.4781966001
+UniRef50_Q2RZU6: tRNA nucleotidyltransferase/poly(A) polymerase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4781966001
+UniRef50_R5NVH9	1.4781966001
+UniRef50_R5NVH9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4781966001
+UniRef50_R5JR48	1.4749262537
+UniRef50_R5JR48|g__Bacteroides.s__Bacteroides_stercoris	1.4749262537
+UniRef50_Q89ZU5	1.4619883041
+UniRef50_Q89ZU5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4619883041
+UniRef50_R5DTE3	1.4619883041
+UniRef50_R5DTE3|g__Bacteroides.s__Bacteroides_stercoris	1.4619883041
+UniRef50_B2RL62: 30S ribosomal protein S2	1.4556040757
+UniRef50_B2RL62: 30S ribosomal protein S2|g__Bacteroides.s__Bacteroides_stercoris	1.4556040757
+UniRef50_R5UMU7	1.4556040757
+UniRef50_R5UMU7|g__Bacteroides.s__Bacteroides_stercoris	1.4556040757
+UniRef50_R7NTE3	1.4513788099
+UniRef50_R7NTE3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4513788099
+UniRef50_L9LVN7: Transposase, mutator family	1.4492753623
+UniRef50_L9LVN7: Transposase, mutator family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4492753623
+UniRef50_R6Z2A5	1.4492753623
+UniRef50_R6Z2A5|g__Bacteroides.s__Bacteroides_stercoris	1.4492753623
+UniRef50_R7ENW3	1.4492753623
+UniRef50_R7ENW3|g__Bacteroides.s__Bacteroides_stercoris	1.4492753623
+UniRef50_Q650K4: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase	1.4430014430
+UniRef50_Q650K4: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase|g__Bacteroides.s__Bacteroides_stercoris	1.4430014430
+UniRef50_R7J997	1.4430014430
+UniRef50_R7J997|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4430014430
+UniRef50_R5NUR5	1.4424902594
+UniRef50_R5NUR5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4424902594
+UniRef50_Q09CP1: Mg-chelatase	1.4398848092
+UniRef50_Q09CP1: Mg-chelatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4398848092
+UniRef50_D6D2P8	1.4367816092
+UniRef50_D6D2P8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4367816092
+UniRef50_I3YJ04	1.4367816092
+UniRef50_I3YJ04|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4367816092
+UniRef50_Q8A5L3: Transcriptional regulator	1.4367816092
+UniRef50_Q8A5L3: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4367816092
+UniRef50_R6ABW6	1.4367816092
+UniRef50_R6ABW6|g__Bacteroides.s__Bacteroides_stercoris	1.4367816092
+UniRef50_Q59219: Intracellular exo-alpha-L-arabinofuranosidase	1.4336917563
+UniRef50_Q59219: Intracellular exo-alpha-L-arabinofuranosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4336917563
+UniRef50_B0NMQ8	1.4306151645
+UniRef50_B0NMQ8|g__Bacteroides.s__Bacteroides_stercoris	1.4306151645
+UniRef50_R5NU10: Prephenate dehydratase	1.4306151645
+UniRef50_R5NU10: Prephenate dehydratase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4306151645
+UniRef50_R6S2C8	1.4306151645
+UniRef50_R6S2C8|g__Bacteroides.s__Bacteroides_stercoris	1.4306151645
+UniRef50_R6D8F5: Solute:sodium symporter (SSS) family transporter	1.4275517488
+UniRef50_R6D8F5: Solute:sodium symporter (SSS) family transporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4275517488
+UniRef50_A6L289: Conserved protein found in conjugate transposon	1.4245014245
+UniRef50_A6L289: Conserved protein found in conjugate transposon|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4245014245
+UniRef50_Q8A0Y5	1.4245014245
+UniRef50_Q8A0Y5|g__Bacteroides.s__Bacteroides_stercoris	1.4245014245
+UniRef50_R6CY54: TrkA C-terminal domain protein	1.4245014245
+UniRef50_R6CY54: TrkA C-terminal domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4245014245
+UniRef50_R6SYJ3	1.4245014245
+UniRef50_R6SYJ3|g__Bacteroides.s__Bacteroides_stercoris	1.4245014245
+UniRef50_A6KY75: Helicase, putative	1.4204545455
+UniRef50_A6KY75: Helicase, putative|g__Bacteroides.s__Bacteroides_stercoris	1.4204545455
+UniRef50_E6SN55: Abortive infection protein	1.4184397163
+UniRef50_E6SN55: Abortive infection protein|g__Bacteroides.s__Bacteroides_stercoris	1.4184397163
+UniRef50_I0KDE7: Undecaprenyl-diphosphatase	1.4184397163
+UniRef50_I0KDE7: Undecaprenyl-diphosphatase|g__Bacteroides.s__Bacteroides_stercoris	1.4184397163
+UniRef50_Q8A6E7	1.4154281670
+UniRef50_Q8A6E7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4154281670
+UniRef50_Q8A827: Glycoside transferase family 2	1.4124293785
+UniRef50_Q8A827: Glycoside transferase family 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4124293785
+UniRef50_R6LIV7: Transcriptional regulator effector binding domain protein	1.4124293785
+UniRef50_R6LIV7: Transcriptional regulator effector binding domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4124293785
+UniRef50_Q8AAD6: Indole-3-glycerol phosphate synthase	1.4064697609
+UniRef50_Q8AAD6: Indole-3-glycerol phosphate synthase|g__Bacteroides.s__Bacteroides_stercoris	1.4064697609
+UniRef50_R5SPN7: Sigma-70 family RNA polymerase sigma factor	1.4064697609
+UniRef50_R5SPN7: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4064697609
+UniRef50_R6HWG1	1.4005602241
+UniRef50_R6HWG1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4005602241
+UniRef50_R6W358	1.4005602241
+UniRef50_R6W358|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4005602241
+UniRef50_R6YU73: Dihydropteroate synthase	1.4005602241
+UniRef50_R6YU73: Dihydropteroate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.4005602241
+UniRef50_A4T8K0: ATP synthase subunit alpha	1.3947001395
+UniRef50_A4T8K0: ATP synthase subunit alpha|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3947001395
+UniRef50_R5MP62	1.3888888889
+UniRef50_R5MP62|g__Bacteroides.s__Bacteroides_stercoris	1.3888888889
+UniRef50_R6W2X5	1.3888888889
+UniRef50_R6W2X5|g__Bacteroides.s__Bacteroides_stercoris	1.3888888889
+UniRef50_Q8AAG5	1.3831258645
+UniRef50_Q8AAG5|g__Bacteroides.s__Bacteroides_stercoris	1.3831258645
+UniRef50_R5C128	1.3831258645
+UniRef50_R5C128|g__Bacteroides.s__Bacteroides_stercoris	1.3831258645
+UniRef50_R6A8R0: HAD hydrolase family IA variant 1	1.3831258645
+UniRef50_R6A8R0: HAD hydrolase family IA variant 1|g__Bacteroides.s__Bacteroides_stercoris	1.3831258645
+UniRef50_R7H6J4: TonB-dependent receptor	1.3825261989
+UniRef50_R7H6J4: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9182736455
+UniRef50_R7H6J4: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_stercoris	0.4642525534
+UniRef50_Q8A1F9: Regulatory protein SusR	1.3802622498
+UniRef50_Q8A1F9: Regulatory protein SusR|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3802622498
+UniRef50_C6IHH9	1.3774104683
+UniRef50_C6IHH9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3774104683
+UniRef50_R6V5Y7	1.3774104683
+UniRef50_R6V5Y7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3774104683
+UniRef50_A0M554: Bifunctional protein FolD	1.3661202186
+UniRef50_A0M554: Bifunctional protein FolD|g__Bacteroides.s__Bacteroides_stercoris	1.3661202186
+UniRef50_F0R285	1.3661202186
+UniRef50_F0R285|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3661202186
+UniRef50_F3ZRK2: Tyrosine recombinase XerC	1.3661202186
+UniRef50_F3ZRK2: Tyrosine recombinase XerC|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3661202186
+UniRef50_Q8A3P4: Transcriptional regulator	1.3661202186
+UniRef50_Q8A3P4: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3661202186
+UniRef50_R5M7G7: Capsular polysaccharide synthesis protein	1.3661202186
+UniRef50_R5M7G7: Capsular polysaccharide synthesis protein|g__Bacteroides.s__Bacteroides_stercoris	1.3661202186
+UniRef50_R6JN12: AP endonuclease family 2	1.3661202186
+UniRef50_R6JN12: AP endonuclease family 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3661202186
+UniRef50_B0NVB0	1.3550135501
+UniRef50_B0NVB0|g__Bacteroides.s__Bacteroides_stercoris	1.3550135501
+UniRef50_F5YJJ6: 2-oxoglutarate oxidoreductase, alpha subunit	1.3550135501
+UniRef50_F5YJJ6: 2-oxoglutarate oxidoreductase, alpha subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3550135501
+UniRef50_P55253: Glucose-1-phosphate thymidylyltransferase	1.3550135501
+UniRef50_P55253: Glucose-1-phosphate thymidylyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3550135501
+UniRef50_R5GBZ4: ABC transporter related protein	1.3550135501
+UniRef50_R5GBZ4: ABC transporter related protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3550135501
+UniRef50_R6W331: YD repeat (Two copies)	1.3495276653
+UniRef50_R6W331: YD repeat (Two copies)|g__Bacteroides.s__Bacteroides_stercoris	1.3495276653
+UniRef50_Q8L7B5: Chaperonin CPN60-like 1, mitochondrial	1.3440860215
+UniRef50_Q8L7B5: Chaperonin CPN60-like 1, mitochondrial|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3440860215
+UniRef50_Q8PYT3: Glycosyltransferase	1.3440860215
+UniRef50_Q8PYT3: Glycosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3440860215
+UniRef50_R6DZ01	1.3440860215
+UniRef50_R6DZ01|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3440860215
+UniRef50_I1YVX8: 1,4-dihydroxy-2-naphthoate octaprenyltransferase	1.3386880857
+UniRef50_I1YVX8: 1,4-dihydroxy-2-naphthoate octaprenyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3386880857
+UniRef50_R6MPT3: LysR substrate binding domain protein	1.3386880857
+UniRef50_R6MPT3: LysR substrate binding domain protein|g__Bacteroides.s__Bacteroides_stercoris	1.3386880857
+UniRef50_R6V9G1	1.3386880857
+UniRef50_R6V9G1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3386880857
+UniRef50_R5KU76	1.3333333333
+UniRef50_R5KU76|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3333333333
+UniRef50_R5TXC7	1.3333333333
+UniRef50_R5TXC7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3333333333
+UniRef50_R6T2Y9: Transcriptional regulator	1.3333333333
+UniRef50_R6T2Y9: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3333333333
+UniRef50_B6EJ93: Imidazole glycerol phosphate synthase subunit HisF	1.3280212483
+UniRef50_B6EJ93: Imidazole glycerol phosphate synthase subunit HisF|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3280212483
+UniRef50_R7CXK0: Deoxyribose-phosphate aldolase	1.3280212483
+UniRef50_R7CXK0: Deoxyribose-phosphate aldolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3280212483
+UniRef50_Q8A269	1.3227513228
+UniRef50_Q8A269|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3227513228
+UniRef50_R5MRY4: Transposase IS4 family	1.3227513228
+UniRef50_R5MRY4: Transposase IS4 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3227513228
+UniRef50_R6JF08	1.3214416680
+UniRef50_R6JF08|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6613756614
+UniRef50_R6JF08|g__Bacteroides.s__Bacteroides_stercoris	0.6600660066
+UniRef50_Q64TC3	1.3201320132
+UniRef50_Q64TC3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3201320132
+UniRef50_D6D339: His Kinase A (Phosphoacceptor) domain./Histidine kinase-, DNA gyrase B-, and HSP90-like ATPase./Response regulator receiver domain	1.3192612137
+UniRef50_D6D339: His Kinase A (Phosphoacceptor) domain./Histidine kinase-, DNA gyrase B-, and HSP90-like ATPase./Response regulator receiver domain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3192612137
+UniRef50_R6B7M5: SusD family protein	1.3175230567
+UniRef50_R6B7M5: SusD family protein|g__Bacteroides.s__Bacteroides_stercoris	1.3175230567
+UniRef50_R6HK33	1.3175230567
+UniRef50_R6HK33|g__Bacteroides.s__Bacteroides_stercoris	1.3175230567
+UniRef50_B0TGQ8: Dihydroorotate dehydrogenase B (NAD(+)), catalytic subunit	1.3123359580
+UniRef50_B0TGQ8: Dihydroorotate dehydrogenase B (NAD(+)), catalytic subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3123359580
+UniRef50_D5EWR9	1.3123359580
+UniRef50_D5EWR9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3123359580
+UniRef50_R5K3A3	1.3123359580
+UniRef50_R5K3A3|g__Bacteroides.s__Bacteroides_stercoris	1.3123359580
+UniRef50_R6ASV6	1.3071895425
+UniRef50_R6ASV6|g__Bacteroides.s__Bacteroides_stercoris	1.3071895425
+UniRef50_R6JIL8	1.3071895425
+UniRef50_R6JIL8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3071895425
+UniRef50_R7D0M9	1.3071895425
+UniRef50_R7D0M9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3071895425
+UniRef50_A3QG19: Homoserine O-succinyltransferase	1.3020833333
+UniRef50_A3QG19: Homoserine O-succinyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3020833333
+UniRef50_R6SK49	1.3020833333
+UniRef50_R6SK49|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3020833333
+UniRef50_R6V714: Transmembrane permease	1.3020833333
+UniRef50_R6V714: Transmembrane permease|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3020833333
+UniRef50_R7KTF4	1.3020833333
+UniRef50_R7KTF4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.3020833333
+UniRef50_R9I2L5	1.3020833333
+UniRef50_R9I2L5|g__Bacteroides.s__Bacteroides_stercoris	1.3020833333
+UniRef50_R7CYA6	1.2970168612
+UniRef50_R7CYA6|g__Bacteroides.s__Bacteroides_stercoris	1.2970168612
+UniRef50_R7DFS4	1.2970168612
+UniRef50_R7DFS4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2970168612
+UniRef50_R7EJ51	1.2970168612
+UniRef50_R7EJ51|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2970168612
+UniRef50_W4PDX5: Immunoreactive 53 kDa antigen PG123	1.2970168612
+UniRef50_W4PDX5: Immunoreactive 53 kDa antigen PG123|g__Bacteroides.s__Bacteroides_stercoris	1.2970168612
+UniRef50_Q8AAE0: Outer membrane protein	1.2970168612
+UniRef50_Q8AAE0: Outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2970168612
+UniRef50_R6JM25	1.2919896641
+UniRef50_R6JM25|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2919896641
+UniRef50_R7LCZ8: YitT family protein	1.2870012870
+UniRef50_R7LCZ8: YitT family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2870012870
+UniRef50_A6H086: Potassium-transporting ATPase A chain	1.2845215157
+UniRef50_A6H086: Potassium-transporting ATPase A chain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2845215157
+UniRef50_D3ICU3	1.2845215157
+UniRef50_D3ICU3|g__Bacteroides.s__Bacteroides_stercoris	1.2845215157
+UniRef50_B0NME1	1.2820512821
+UniRef50_B0NME1|g__Bacteroides.s__Bacteroides_stercoris	1.2820512821
+UniRef50_R7NZJ6	1.2820512821
+UniRef50_R7NZJ6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2820512821
+UniRef50_R6EBA6	1.2771392082
+UniRef50_R6EBA6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2771392082
+UniRef50_D7J4L8: Glycosyl transferase, family 8	1.2722646310
+UniRef50_D7J4L8: Glycosyl transferase, family 8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2722646310
+UniRef50_R5MD26: Sigma factor regulatory protein FecR/PupR family	1.2722646310
+UniRef50_R5MD26: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2722646310
+UniRef50_R5UTD2: Riboflavin biosynthesis protein RibF	1.2722646310
+UniRef50_R5UTD2: Riboflavin biosynthesis protein RibF|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2722646310
+UniRef50_R6ABT7: Sigma factor regulatory protein FecR/PupR family	1.2722646310
+UniRef50_R6ABT7: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides.s__Bacteroides_stercoris	1.2722646310
+UniRef50_Q5L8Z8: Malate dehydrogenase	1.2626262626
+UniRef50_Q5L8Z8: Malate dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	1.2626262626
+UniRef50_Q8A9S3: Aspartate carbamoyltransferase	1.2626262626
+UniRef50_Q8A9S3: Aspartate carbamoyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2626262626
+UniRef50_Q8AAJ1: Glycoside transferase family 2	1.2626262626
+UniRef50_Q8AAJ1: Glycoside transferase family 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2626262626
+UniRef50_E1WVW3	1.2594458438
+UniRef50_E1WVW3|g__Bacteroides.s__Bacteroides_stercoris	1.2594458438
+UniRef50_R6DGF7	1.2578616352
+UniRef50_R6DGF7|g__Bacteroides.s__Bacteroides_stercoris	1.2578616352
+UniRef50_R6D3Z1	1.2554972337
+UniRef50_R6D3Z1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2554972337
+UniRef50_Q8A9W0	1.2531328321
+UniRef50_Q8A9W0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2531328321
+UniRef50_R6JA28	1.2531328321
+UniRef50_R6JA28|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2531328321
+UniRef50_F2KVV0: DNA gyrase/topoisomerase IV, A subunit	1.2484394507
+UniRef50_F2KVV0: DNA gyrase/topoisomerase IV, A subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_Q8AB21: Integrase	1.2484394507
+UniRef50_Q8AB21: Integrase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_R6JJ68	1.2484394507
+UniRef50_R6JJ68|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_R6RPC2: Transcriptional regulator	1.2484394507
+UniRef50_R6RPC2: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_R6YFA8	1.2484394507
+UniRef50_R6YFA8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2484394507
+UniRef50_D5EH68: NAD-dependent epimerase/dehydratase	1.2391573730
+UniRef50_D5EH68: NAD-dependent epimerase/dehydratase|g__Bacteroides.s__Bacteroides_stercoris	1.2391573730
+UniRef50_Q8A0B5: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase 2	1.2391573730
+UniRef50_Q8A0B5: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase 2|g__Bacteroides.s__Bacteroides_stercoris	1.2391573730
+UniRef50_Q8A1E9: N-acetylornithine carbamoyltransferase	1.2391573730
+UniRef50_Q8A1E9: N-acetylornithine carbamoyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2391573730
+UniRef50_R6RWC3: Phosphatidate cytidylyltransferase	1.2391573730
+UniRef50_R6RWC3: Phosphatidate cytidylyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2391573730
+UniRef50_R7PC42	1.2391573730
+UniRef50_R7PC42|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2391573730
+UniRef50_R5FP64: DNA gyrase subunit A	1.2360939431
+UniRef50_R5FP64: DNA gyrase subunit A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2360939431
+UniRef50_R6B3N2: ATPase AAA family	1.2345679012
+UniRef50_R6B3N2: ATPase AAA family|g__Bacteroides.s__Bacteroides_stercoris	1.2345679012
+UniRef50_R6XVK0: Signal recognition particle receptor FtsY	1.2345679012
+UniRef50_R6XVK0: Signal recognition particle receptor FtsY|g__Bacteroides.s__Bacteroides_stercoris	1.2345679012
+UniRef50_R7KZF1	1.2345679012
+UniRef50_R7KZF1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2345679012
+UniRef50_R5I2X5: Phage RecT family recombinase	1.2300123001
+UniRef50_R5I2X5: Phage RecT family recombinase|g__Bacteroides.s__Bacteroides_stercoris	1.2300123001
+UniRef50_Q9JS61: Dihydroxy-acid dehydratase	1.2268512248
+UniRef50_Q9JS61: Dihydroxy-acid dehydratase|g__Bacteroides.s__Bacteroides_stercoris	0.6218905473
+UniRef50_Q9JS61: Dihydroxy-acid dehydratase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6049606776
+UniRef50_A6L0Q1	1.2210012210
+UniRef50_A6L0Q1|g__Bacteroides.s__Bacteroides_stercoris	1.2210012210
+UniRef50_Q5LHZ1: N-acetyl-gamma-glutamyl-phosphate reductase	1.2210012210
+UniRef50_Q5LHZ1: N-acetyl-gamma-glutamyl-phosphate reductase|g__Bacteroides.s__Bacteroides_stercoris	1.2210012210
+UniRef50_Q8A5U0: Glycoside transferase family 4	1.2165450122
+UniRef50_Q8A5U0: Glycoside transferase family 4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2165450122
+UniRef50_Q8ABR0: Glycoside transferase family 2	1.2165450122
+UniRef50_Q8ABR0: Glycoside transferase family 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2165450122
+UniRef50_R5BYQ9: Mannose-6-phosphate isomerase class I	1.2165450122
+UniRef50_R5BYQ9: Mannose-6-phosphate isomerase class I|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2165450122
+UniRef50_R6SE59	1.2143290832
+UniRef50_R6SE59|g__Bacteroides.s__Bacteroides_stercoris	1.2143290832
+UniRef50_W4US16: Alanine--tRNA ligase	1.2135922330
+UniRef50_W4US16: Alanine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	1.2135922330
+UniRef50_E4T664: Polyprenyl synthetase	1.2121212121
+UniRef50_E4T664: Polyprenyl synthetase|g__Bacteroides.s__Bacteroides_stercoris	1.2121212121
+UniRef50_L7WG82: ATPase, AAA_3 family	1.2121212121
+UniRef50_L7WG82: ATPase, AAA_3 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2121212121
+UniRef50_Q7MWA2: D-alanine--D-alanine ligase	1.2121212121
+UniRef50_Q7MWA2: D-alanine--D-alanine ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2121212121
+UniRef50_R6ABJ5: Cobalamin biosynthesis protein CobD	1.2121212121
+UniRef50_R6ABJ5: Cobalamin biosynthesis protein CobD|g__Bacteroides.s__Bacteroides_stercoris	1.2121212121
+UniRef50_R6JBQ5	1.2121212121
+UniRef50_R6JBQ5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2121212121
+UniRef50_R6U2U2: Mannose-6-phosphate isomerase type 1	1.2121212121
+UniRef50_R6U2U2: Mannose-6-phosphate isomerase type 1|g__Bacteroides.s__Bacteroides_stercoris	1.2121212121
+UniRef50_R7KQZ5: Surface layer protein	1.2121212121
+UniRef50_R7KQZ5: Surface layer protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2121212121
+UniRef50_R6AB99	1.2077294686
+UniRef50_R6AB99|g__Bacteroides.s__Bacteroides_stercoris	1.2077294686
+UniRef50_R6EIX3	1.2077294686
+UniRef50_R6EIX3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2077294686
+UniRef50_S3Y6P5	1.2077294686
+UniRef50_S3Y6P5|g__Bacteroides.s__Bacteroides_stercoris	1.2077294686
+UniRef50_Q89ZM4: Valine--tRNA ligase	1.2048192771
+UniRef50_Q89ZM4: Valine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2048192771
+UniRef50_Q8A624: ATP-dependent 6-phosphofructokinase 2	1.2033694344
+UniRef50_Q8A624: ATP-dependent 6-phosphofructokinase 2|g__Bacteroides.s__Bacteroides_stercoris	1.2033694344
+UniRef50_A6L2H0: Glycoside hydrolase family 2, candidate beta-glycosidase	1.2012012012
+UniRef50_A6L2H0: Glycoside hydrolase family 2, candidate beta-glycosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.2012012012
+UniRef50_R5IKU0: UDP-N-acetylenolpyruvoylglucosamine reductase	1.1990407674
+UniRef50_R5IKU0: UDP-N-acetylenolpyruvoylglucosamine reductase|g__Bacteroides.s__Bacteroides_stercoris	1.1990407674
+UniRef50_R6JN09: Sigma factor regulatory protein FecR/PupR family	1.1990407674
+UniRef50_R6JN09: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides.s__Bacteroides_stercoris	1.1990407674
+UniRef50_W0EUZ5: Membrane protein	1.1990407674
+UniRef50_W0EUZ5: Membrane protein|g__Bacteroides.s__Bacteroides_stercoris	1.1990407674
+UniRef50_R5NT69	1.1947431302
+UniRef50_R5NT69|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1947431302
+UniRef50_R6F307: Auxiliary transport protein membrane fusion protein (MFP) family protein	1.1947431302
+UniRef50_R6F307: Auxiliary transport protein membrane fusion protein (MFP) family protein|g__Bacteroides.s__Bacteroides_stercoris	1.1947431302
+UniRef50_G8TJF7: Transposase IS204/IS1001/IS1096/IS1165 family protein	1.1933174224
+UniRef50_G8TJF7: Transposase IS204/IS1001/IS1096/IS1165 family protein|g__Bacteroides.s__Bacteroides_stercoris	1.1933174224
+UniRef50_D6CYP9: Beta-xylosidase	1.1904761905
+UniRef50_D6CYP9: Beta-xylosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1904761905
+UniRef50_R5JP39: PfkB family carbohydrate kinase	1.1904761905
+UniRef50_R5JP39: PfkB family carbohydrate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1904761905
+UniRef50_A6LEG5: DNA-directed RNA polymerase subunit alpha	1.1862396204
+UniRef50_A6LEG5: DNA-directed RNA polymerase subunit alpha|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1862396204
+UniRef50_Q043T3: Integrase	1.1862396204
+UniRef50_Q043T3: Integrase|g__Bacteroides.s__Bacteroides_stercoris	1.1862396204
+UniRef50_Q8A4G5: Putative integrase/recombinase	1.1862396204
+UniRef50_Q8A4G5: Putative integrase/recombinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1862396204
+UniRef50_R6YSY2	1.1862396204
+UniRef50_R6YSY2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1862396204
+UniRef50_J0S1M2: ATPase associated with various cellular activities AAA_3	1.1820330969
+UniRef50_J0S1M2: ATPase associated with various cellular activities AAA_3|g__Bacteroides.s__Bacteroides_stercoris	1.1820330969
+UniRef50_K6BKY7	1.1820330969
+UniRef50_K6BKY7|g__Bacteroides.s__Bacteroides_stercoris	1.1820330969
+UniRef50_R5V0C7: Peptidase M28 family	1.1820330969
+UniRef50_R5V0C7: Peptidase M28 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1820330969
+UniRef50_F0P1A4: Nicotinate-nucleotide pyrophosphorylase	1.1778563015
+UniRef50_F0P1A4: Nicotinate-nucleotide pyrophosphorylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1778563015
+UniRef50_F9D2R9: Pyruvate synthase	1.1778563015
+UniRef50_F9D2R9: Pyruvate synthase|g__Bacteroides.s__Bacteroides_stercoris	1.1778563015
+UniRef50_Q5LC41: Membrane protein insertase YidC	1.1747512322
+UniRef50_Q5LC41: Membrane protein insertase YidC|g__Bacteroides.s__Bacteroides_stercoris	0.5889281508
+UniRef50_Q5LC41: Membrane protein insertase YidC|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5858230814
+UniRef50_Q7UQD2: UPF0365 protein RB6389	1.1737089202
+UniRef50_Q7UQD2: UPF0365 protein RB6389|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1737089202
+UniRef50_C6W2Y1: Oxidoreductase domain protein	1.1695906433
+UniRef50_C6W2Y1: Oxidoreductase domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1695906433
+UniRef50_R5JDR7	1.1695906433
+UniRef50_R5JDR7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1695906433
+UniRef50_R6L6N2	1.1695906433
+UniRef50_R6L6N2|g__Bacteroides.s__Bacteroides_stercoris	1.1695906433
+UniRef50_R7KTX1	1.1668611435
+UniRef50_R7KTX1|g__Bacteroides.s__Bacteroides_stercoris	1.1668611435
+UniRef50_A6L8M1	1.1655011655
+UniRef50_A6L8M1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1655011655
+UniRef50_O83668: Fructose-bisphosphate aldolase	1.1614401858
+UniRef50_O83668: Fructose-bisphosphate aldolase|g__Bacteroides.s__Bacteroides_stercoris	1.1614401858
+UniRef50_R5JNN6	1.1614401858
+UniRef50_R5JNN6|g__Bacteroides.s__Bacteroides_stercoris	1.1614401858
+UniRef50_A6KYD5: Aldose 1-epimerase	1.1574074074
+UniRef50_A6KYD5: Aldose 1-epimerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1574074074
+UniRef50_F3ZPR6: Endonuclease/exonuclease/phosphatase	1.1574074074
+UniRef50_F3ZPR6: Endonuclease/exonuclease/phosphatase|g__Bacteroides.s__Bacteroides_stercoris	1.1574074074
+UniRef50_P71103: Phosphate acetyltransferase	1.1534025375
+UniRef50_P71103: Phosphate acetyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.1534025375
+UniRef50_F4KN33: Branched-chain amino acid aminotransferase	1.1494252874
+UniRef50_F4KN33: Branched-chain amino acid aminotransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1494252874
+UniRef50_F9D1I7	1.1494252874
+UniRef50_F9D1I7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1494252874
+UniRef50_R7KHJ8	1.1494252874
+UniRef50_R7KHJ8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1494252874
+UniRef50_A6L012: Biosynthetic arginine decarboxylase	1.1474469306
+UniRef50_A6L012: Biosynthetic arginine decarboxylase|g__Bacteroides.s__Bacteroides_stercoris	0.5737234653
+UniRef50_A6L012: Biosynthetic arginine decarboxylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5737234653
+UniRef50_Q64X44: Thiamine biosynthesis lipoprotein ApbE	1.1454753723
+UniRef50_Q64X44: Thiamine biosynthesis lipoprotein ApbE|g__Bacteroides.s__Bacteroides_stercoris	1.1454753723
+UniRef50_Q89YI4	1.1454753723
+UniRef50_Q89YI4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1454753723
+UniRef50_R6ALI4	1.1454753723
+UniRef50_R6ALI4|g__Bacteroides.s__Bacteroides_stercoris	1.1454753723
+UniRef50_R6FQM9	1.1454753723
+UniRef50_R6FQM9|g__Bacteroides.s__Bacteroides_stercoris	1.1454753723
+UniRef50_R6AGI9: Efflux transporter RND family MFP subunit	1.1376564278
+UniRef50_R6AGI9: Efflux transporter RND family MFP subunit|g__Bacteroides.s__Bacteroides_stercoris	1.1376564278
+UniRef50_R6JI28: Auxiliary transport protein membrane fusion protein (MFP) family protein	1.1376564278
+UniRef50_R6JI28: Auxiliary transport protein membrane fusion protein (MFP) family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1376564278
+UniRef50_R6EYN4: Heptosyltransferase	1.1337868481
+UniRef50_R6EYN4: Heptosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1337868481
+UniRef50_R6J7D8	1.1337868481
+UniRef50_R6J7D8|g__Bacteroides.s__Bacteroides_stercoris	1.1337868481
+UniRef50_Q8I0H7: Heat shock 70 kDa protein, mitochondrial	1.1309027078
+UniRef50_Q8I0H7: Heat shock 70 kDa protein, mitochondrial|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5659309564
+UniRef50_Q8I0H7: Heat shock 70 kDa protein, mitochondrial|g__Bacteroides.s__Bacteroides_stercoris	0.5649717514
+UniRef50_Q6LMU2: Protein RecA	1.1299435028
+UniRef50_Q6LMU2: Protein RecA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1299435028
+UniRef50_R6SBV4	1.1299435028
+UniRef50_R6SBV4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1299435028
+UniRef50_D6DM26: Iron-only hydrogenase maturation protein HydE	1.1261261261
+UniRef50_D6DM26: Iron-only hydrogenase maturation protein HydE|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1261261261
+UniRef50_C6XV67: Glycosidase PH1107-related	1.1185682327
+UniRef50_C6XV67: Glycosidase PH1107-related|g__Bacteroides.s__Bacteroides_stercoris	1.1185682327
+UniRef50_R6AKT0	1.1185682327
+UniRef50_R6AKT0|g__Bacteroides.s__Bacteroides_stercoris	1.1185682327
+UniRef50_R6CEQ7: A/G-specific adenine glycosylase	1.1148272018
+UniRef50_R6CEQ7: A/G-specific adenine glycosylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1148272018
+UniRef50_Q650E6: TraA	1.1111111111
+UniRef50_Q650E6: TraA|g__Bacteroides.s__Bacteroides_stercoris	1.1111111111
+UniRef50_Q8A1H6: Beta-glucanase	1.1111111111
+UniRef50_Q8A1H6: Beta-glucanase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1111111111
+UniRef50_Q8A2E4: Erythronate-4-phosphate dehydrogenase	1.1111111111
+UniRef50_Q8A2E4: Erythronate-4-phosphate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1111111111
+UniRef50_Q8A345	1.1098779134
+UniRef50_Q8A345|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1098779134
+UniRef50_A0A024GWJ3: Uridine diphosphate galacturonate 4-epimerase	1.1074197121
+UniRef50_A0A024GWJ3: Uridine diphosphate galacturonate 4-epimerase|g__Bacteroides.s__Bacteroides_stercoris	1.1074197121
+UniRef50_S3YBR0	1.1074197121
+UniRef50_S3YBR0|g__Bacteroides.s__Bacteroides_stercoris	1.1074197121
+UniRef50_D7J4M8: Transcriptional regulatory protein	1.1037527594
+UniRef50_D7J4M8: Transcriptional regulatory protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1037527594
+UniRef50_R7NTA9	1.1037527594
+UniRef50_R7NTA9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1037527594
+UniRef50_A7IH78: Choloylglycine hydrolase	1.1001100110
+UniRef50_A7IH78: Choloylglycine hydrolase|g__Bacteroides.s__Bacteroides_stercoris	1.1001100110
+UniRef50_B6YR69: S-adenosylmethionine:tRNA ribosyltransferase-isomerase	1.1001100110
+UniRef50_B6YR69: S-adenosylmethionine:tRNA ribosyltransferase-isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.1001100110
+UniRef50_G8UNW9: Efflux transporter, RND family, MFP subunit	1.0964912281
+UniRef50_G8UNW9: Efflux transporter, RND family, MFP subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0964912281
+UniRef50_Q8A2R1	1.0928961749
+UniRef50_Q8A2R1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0928961749
+UniRef50_B2RID6: Phosphoserine aminotransferase	1.0893246187
+UniRef50_B2RID6: Phosphoserine aminotransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0893246187
+UniRef50_F9D3S7: M20A family peptidase	1.0893246187
+UniRef50_F9D3S7: M20A family peptidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0893246187
+UniRef50_R6ZR61: Efflux transporter RND family MFP subunit	1.0893246187
+UniRef50_R6ZR61: Efflux transporter RND family MFP subunit|g__Bacteroides.s__Bacteroides_stercoris	1.0893246187
+UniRef50_R5C5X4	1.0875504744
+UniRef50_R5C5X4|g__Bacteroides.s__Bacteroides_stercoris	0.5446623094
+UniRef50_R5C5X4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5428881650
+UniRef50_H0UKG1: Urocanate hydratase	1.0857763301
+UniRef50_H0UKG1: Urocanate hydratase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0857763301
+UniRef50_Q8A898: Component of multidrug efflux system	1.0857763301
+UniRef50_Q8A898: Component of multidrug efflux system|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0857763301
+UniRef50_Q8ABV0	1.0822510823
+UniRef50_Q8ABV0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0822510823
+UniRef50_R5C915	1.0822510823
+UniRef50_R5C915|g__Bacteroides.s__Bacteroides_stercoris	1.0822510823
+UniRef50_R6AFI7: Kinase PfkB family	1.0822510823
+UniRef50_R6AFI7: Kinase PfkB family|g__Bacteroides.s__Bacteroides_stercoris	1.0822510823
+UniRef50_A3PAU4: Chorismate synthase	1.0787486516
+UniRef50_A3PAU4: Chorismate synthase|g__Bacteroides.s__Bacteroides_stercoris	1.0787486516
+UniRef50_R6MAF9	1.0787486516
+UniRef50_R6MAF9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0787486516
+UniRef50_Q8A4R5: SusD homolog	1.0780351002
+UniRef50_Q8A4R5: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0780351002
+UniRef50_R6ALH7: TonB-linked outer membrane protein SusC/RagA family	1.0775862069
+UniRef50_R6ALH7: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides.s__Bacteroides_stercoris	1.0775862069
+UniRef50_F0SDG2: Glycosyl hydrolase family 88	1.0718113612
+UniRef50_F0SDG2: Glycosyl hydrolase family 88|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0718113612
+UniRef50_Q8A2E8: Ribonuclease 3	1.0649627263
+UniRef50_Q8A2E8: Ribonuclease 3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0649627263
+UniRef50_Q8A6Q6: Pyruvate dehydrogenase	1.0649627263
+UniRef50_Q8A6Q6: Pyruvate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0649627263
+UniRef50_R5ALN9: Conjugative transposon protein TraG	1.0649627263
+UniRef50_R5ALN9: Conjugative transposon protein TraG|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0649627263
+UniRef50_R6ETZ6: Pyruvate phosphate dikinase PEP/pyruvate binding domain protein	1.0642082362
+UniRef50_R6ETZ6: Pyruvate phosphate dikinase PEP/pyruvate binding domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.7099751509
+UniRef50_R6ETZ6: Pyruvate phosphate dikinase PEP/pyruvate binding domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3542330854
+UniRef50_R7F5F2: Integrase family protein	1.0615711253
+UniRef50_R7F5F2: Integrase family protein|g__Bacteroides.s__Bacteroides_stercoris	1.0615711253
+UniRef50_A0A016FAQ7: N-6 DNA Methylase family protein (Fragment)	1.0583263888
+UniRef50_A0A016FAQ7: N-6 DNA Methylase family protein (Fragment)|g__Bacteroides.s__Bacteroides_stercoris	1.0583263888
+UniRef50_A6L242: Transposase	1.0582010582
+UniRef50_A6L242: Transposase|g__Bacteroides.s__Bacteroides_stercoris	1.0582010582
+UniRef50_B3CBX4: Dinuclear metal center protein, YbgI family	1.0582010582
+UniRef50_B3CBX4: Dinuclear metal center protein, YbgI family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0582010582
+UniRef50_Q89ZK3: 4-hydroxythreonine-4-phosphate dehydrogenase	1.0582010582
+UniRef50_Q89ZK3: 4-hydroxythreonine-4-phosphate dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0582010582
+UniRef50_Q8AAS0: Capsular polysaccharide biosynthesis glycosyltransferase	1.0582010582
+UniRef50_Q8AAS0: Capsular polysaccharide biosynthesis glycosyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0582010582
+UniRef50_Q89ZF7	1.0548523207
+UniRef50_Q89ZF7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0548523207
+UniRef50_R5CHL6	1.0548523207
+UniRef50_R5CHL6|g__Bacteroides.s__Bacteroides_stercoris	1.0548523207
+UniRef50_R7DK98: ATP-binding protein Mrp/Nbp35 family	1.0548523207
+UniRef50_R7DK98: ATP-binding protein Mrp/Nbp35 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0548523207
+UniRef50_R5F658: Alpha-glucosidase II	1.0515247108
+UniRef50_R5F658: Alpha-glucosidase II|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0515247108
+UniRef50_R7D1E2: Thioredoxin family protein	1.0515247108
+UniRef50_R7D1E2: Thioredoxin family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0515247108
+UniRef50_Q8A2J5: SusC homolog	1.0504201681
+UniRef50_Q8A2J5: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0504201681
+UniRef50_Q8A2A1: Translation initiation factor IF-2	1.0486112908
+UniRef50_Q8A2A1: Translation initiation factor IF-2|g__Bacteroides.s__Bacteroides_stercoris	0.7122507123
+UniRef50_Q8A2A1: Translation initiation factor IF-2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3363605785
+UniRef50_S3ZKH9	1.0482180294
+UniRef50_S3ZKH9|g__Bacteroides.s__Bacteroides_stercoris	1.0482180294
+UniRef50_R5JS40	1.0465724751
+UniRef50_R5JS40|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0465724751
+UniRef50_A6L0K3: Undecaprenyl-phosphate alpha-N-acetylglucosaminyltransferase	1.0449320794
+UniRef50_A6L0K3: Undecaprenyl-phosphate alpha-N-acetylglucosaminyltransferase|g__Bacteroides.s__Bacteroides_stercoris	1.0449320794
+UniRef50_R5RER3: Six-hairpin glycosidase	1.0449320794
+UniRef50_R5RER3: Six-hairpin glycosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0449320794
+UniRef50_R6S6T5: TPR-domain containing protein	1.0431278273
+UniRef50_R6S6T5: TPR-domain containing protein|g__Bacteroides.s__Bacteroides_stercoris	0.6937218176
+UniRef50_R6S6T5: TPR-domain containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3494060098
+UniRef50_G8UI78	1.0416666667
+UniRef50_G8UI78|g__Bacteroides.s__Bacteroides_stercoris	1.0416666667
+UniRef50_R5UMK2	1.0416666667
+UniRef50_R5UMK2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0416666667
+UniRef50_R5K747: Response regulator receiver domain-containing protein	1.0408534999
+UniRef50_R5K747: Response regulator receiver domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0408534999
+UniRef50_R5JDJ3	1.0400416017
+UniRef50_R5JDJ3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0400416017
+UniRef50_Q64YW0: Beta-N-acetylglucosaminidase	1.0395010395
+UniRef50_Q64YW0: Beta-N-acetylglucosaminidase|g__Bacteroides.s__Bacteroides_stercoris	1.0395010395
+UniRef50_Q8A715	1.0384215992
+UniRef50_Q8A715|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0384215992
+UniRef50_R7NV35: Thiol:disulfide interchange protein	1.0384215992
+UniRef50_R7NV35: Thiol:disulfide interchange protein|g__Bacteroides.s__Bacteroides_stercoris	1.0384215992
+UniRef50_R5EYM2	1.0368066356
+UniRef50_R5EYM2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0368066356
+UniRef50_F3ZPH8: DEAD/DEAH box helicase domain protein	1.0319917441
+UniRef50_F3ZPH8: DEAD/DEAH box helicase domain protein|g__Bacteroides.s__Bacteroides_stercoris	1.0319917441
+UniRef50_R5S0C0	1.0319917441
+UniRef50_R5S0C0|g__Bacteroides.s__Bacteroides_stercoris	1.0319917441
+UniRef50_R5S2A9: DNA topoisomerase	1.0319917441
+UniRef50_R5S2A9: DNA topoisomerase|g__Bacteroides.s__Bacteroides_stercoris	1.0319917441
+UniRef50_E4T5E0: DNA polymerase III subunit beta	1.0256410256
+UniRef50_E4T5E0: DNA polymerase III subunit beta|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0256410256
+UniRef50_R5USZ9	1.0256410256
+UniRef50_R5USZ9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0256410256
+UniRef50_C6W0S7	1.0193679918
+UniRef50_C6W0S7|g__Bacteroides.s__Bacteroides_stercoris	1.0193679918
+UniRef50_F0R3K7	1.0193679918
+UniRef50_F0R3K7|g__Bacteroides.s__Bacteroides_stercoris	1.0193679918
+UniRef50_R6AMD8	1.0193679918
+UniRef50_R6AMD8|g__Bacteroides.s__Bacteroides_stercoris	1.0193679918
+UniRef50_R6ACB7	1.0167890221
+UniRef50_R6ACB7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5265929437
+UniRef50_R6ACB7|g__Bacteroides.s__Bacteroides_stercoris	0.4901960784
+UniRef50_D6Z4R5: Phosphonopyruvate decarboxylase	1.0162601626
+UniRef50_D6Z4R5: Phosphonopyruvate decarboxylase|g__Bacteroides.s__Bacteroides_stercoris	1.0162601626
+UniRef50_Q8AAT0	1.0162601626
+UniRef50_Q8AAT0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0162601626
+UniRef50_R6LJY6: Aldose 1-epimerase	1.0162601626
+UniRef50_R6LJY6: Aldose 1-epimerase|g__Bacteroides.s__Bacteroides_stercoris	1.0162601626
+UniRef50_R6XYG2: Signal transduction histidine kinase	1.0162601626
+UniRef50_R6XYG2: Signal transduction histidine kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0162601626
+UniRef50_E6SR52: Glycoside hydrolase family 2 TIM barrel	1.0148907969
+UniRef50_E6SR52: Glycoside hydrolase family 2 TIM barrel|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6754474840
+UniRef50_E6SR52: Glycoside hydrolase family 2 TIM barrel|g__Bacteroides.s__Bacteroides_stercoris	0.3394433130
+UniRef50_R5CR17: Lipid A disaccharide synthase	1.0131712259
+UniRef50_R5CR17: Lipid A disaccharide synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0131712259
+UniRef50_R5W1I4	1.0131712259
+UniRef50_R5W1I4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0131712259
+UniRef50_R5F9D0: Carboxynorspermidine decarboxylase	1.0101010101
+UniRef50_R5F9D0: Carboxynorspermidine decarboxylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0101010101
+UniRef50_R6SEZ6: dTDP-glucose 4,6-dehydratase	1.0101010101
+UniRef50_R6SEZ6: dTDP-glucose 4,6-dehydratase|g__Bacteroides.s__Bacteroides_stercoris	1.0101010101
+UniRef50_R5S9I0	1.0055304173
+UniRef50_R5S9I0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0055304173
+UniRef50_K6A700	1.0040160643
+UniRef50_K6A700|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0040160643
+UniRef50_Q8AAR5: Tyrosine-protein kinase ptk involved in exopolysaccharide biosynthesis	1.0040160643
+UniRef50_Q8AAR5: Tyrosine-protein kinase ptk involved in exopolysaccharide biosynthesis|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0040160643
+UniRef50_D6D1V7: Glycosyl hydrolase family 71	1.0010010010
+UniRef50_D6D1V7: Glycosyl hydrolase family 71|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0010010010
+UniRef50_Q5LIJ7: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase	1.0010010010
+UniRef50_Q5LIJ7: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase|g__Bacteroides.s__Bacteroides_stercoris	1.0010010010
+UniRef50_R7PCK6: Acyltransferase	1.0010010010
+UniRef50_R7PCK6: Acyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	1.0010010010
+UniRef50_R6VPD1	0.9990009990
+UniRef50_R6VPD1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9990009990
+UniRef50_G8UIS7: Transposase, IS116/IS110/IS902 family	0.9980039920
+UniRef50_G8UIS7: Transposase, IS116/IS110/IS902 family|g__Bacteroides.s__Bacteroides_stercoris	0.9980039920
+UniRef50_R6A607: LysM domain protein	0.9980039920
+UniRef50_R6A607: LysM domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.9980039920
+UniRef50_W0F1V4: Transcriptional regulator	0.9980039920
+UniRef50_W0F1V4: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9980039920
+UniRef50_D5EW43: Endoribonuclease L-PSP family protein	0.9950248756
+UniRef50_D5EW43: Endoribonuclease L-PSP family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9950248756
+UniRef50_R7DJ00	0.9950248756
+UniRef50_R7DJ00|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9950248756
+UniRef50_F0R5K7	0.9920634921
+UniRef50_F0R5K7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9920634921
+UniRef50_R6FAN6	0.9920634921
+UniRef50_R6FAN6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9920634921
+UniRef50_R6XYW2	0.9920634921
+UniRef50_R6XYW2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9920634921
+UniRef50_R5V7Y5	0.9910802775
+UniRef50_R5V7Y5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9910802775
+UniRef50_K6BE56	0.9891196835
+UniRef50_K6BE56|g__Bacteroides.s__Bacteroides_stercoris	0.9891196835
+UniRef50_R5NU14: Glycosyl hydrolase family 88	0.9891196835
+UniRef50_R5NU14: Glycosyl hydrolase family 88|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9891196835
+UniRef50_R6L7L5: ABC transporter ATP-binding protein	0.9861932939
+UniRef50_R6L7L5: ABC transporter ATP-binding protein|g__Bacteroides.s__Bacteroides_stercoris	0.9861932939
+UniRef50_Q3AUF2: Phosphoribosylglycinamide formyltransferase 2	0.9832841691
+UniRef50_Q3AUF2: Phosphoribosylglycinamide formyltransferase 2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9832841691
+UniRef50_Q8A1Z3: Putatuve glycosylhydrolase	0.9803921569
+UniRef50_Q8A1Z3: Putatuve glycosylhydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9803921569
+UniRef50_R7DGM8	0.9803921569
+UniRef50_R7DGM8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9803921569
+UniRef50_R7LCF1	0.9803921569
+UniRef50_R7LCF1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9803921569
+UniRef50_B0NP73: Glycosyltransferase, group 1 family protein	0.9775171065
+UniRef50_B0NP73: Glycosyltransferase, group 1 family protein|g__Bacteroides.s__Bacteroides_stercoris	0.9775171065
+UniRef50_Q8A684: 1-deoxy-D-xylulose 5-phosphate reductoisomerase	0.9775171065
+UniRef50_Q8A684: 1-deoxy-D-xylulose 5-phosphate reductoisomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9775171065
+UniRef50_R7NTP3: Glutamine-dependent carbamyl phosphate synthetase	0.9765625000
+UniRef50_R7NTP3: Glutamine-dependent carbamyl phosphate synthetase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9765625000
+UniRef50_F3ZUS7: ATP synthase subunit a	0.9746588694
+UniRef50_F3ZUS7: ATP synthase subunit a|g__Bacteroides.s__Bacteroides_stercoris	0.9746588694
+UniRef50_R5K881	0.9746588694
+UniRef50_R5K881|g__Bacteroides.s__Bacteroides_stercoris	0.9746588694
+UniRef50_R5NW37	0.9746588694
+UniRef50_R5NW37|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9746588694
+UniRef50_R5M3D3: Peptidase S9A/B/C family catalytic domain protein	0.9689942952
+UniRef50_R5M3D3: Peptidase S9A/B/C family catalytic domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4852013586
+UniRef50_R5M3D3: Peptidase S9A/B/C family catalytic domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.4837929366
+UniRef50_D6D387: Relaxase/Mobilisation nuclease domain	0.9689922481
+UniRef50_D6D387: Relaxase/Mobilisation nuclease domain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9689922481
+UniRef50_E0RYL3: UDP-N-acetylglucosamine 2-epimerase	0.9689922481
+UniRef50_E0RYL3: UDP-N-acetylglucosamine 2-epimerase|g__Bacteroides.s__Bacteroides_stercoris	0.9689922481
+UniRef50_R5ZWQ4: Isocitrate dehydrogenase [NADP]	0.9689922481
+UniRef50_R5ZWQ4: Isocitrate dehydrogenase [NADP]|g__Bacteroides.s__Bacteroides_stercoris	0.9689922481
+UniRef50_R7DKK4	0.9689922481
+UniRef50_R7DKK4|g__Bacteroides.s__Bacteroides_stercoris	0.9689922481
+UniRef50_R7NRS3: Aminotransferase	0.9689922481
+UniRef50_R7NRS3: Aminotransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9689922481
+UniRef50_Q2S1Q6: DNA-directed RNA polymerase subunit beta'	0.9675858732
+UniRef50_Q2S1Q6: DNA-directed RNA polymerase subunit beta'|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9675858732
+UniRef50_C9RPC9	0.9661835749
+UniRef50_C9RPC9|g__Bacteroides.s__Bacteroides_stercoris	0.9661835749
+UniRef50_F9D1D7: Aminopeptidase C (Bleomycin hydrolase)	0.9661835749
+UniRef50_F9D1D7: Aminopeptidase C (Bleomycin hydrolase)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9661835749
+UniRef50_Q9TMM9: Elongation factor Tu, apicoplast	0.9661835749
+UniRef50_Q9TMM9: Elongation factor Tu, apicoplast|g__Bacteroides.s__Bacteroides_stercoris	0.9661835749
+UniRef50_R5CGY7	0.9661835749
+UniRef50_R5CGY7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9661835749
+UniRef50_R5I2S0	0.9661835749
+UniRef50_R5I2S0|g__Bacteroides.s__Bacteroides_stercoris	0.9661835749
+UniRef50_R6K531: Uracil-xanthine permease	0.9661835749
+UniRef50_R6K531: Uracil-xanthine permease|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9661835749
+UniRef50_R7KRX4: Anti-sigma factor	0.9661835749
+UniRef50_R7KRX4: Anti-sigma factor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9661835749
+UniRef50_R7LKK3: ABC-2 type transporter	0.9661835749
+UniRef50_R7LKK3: ABC-2 type transporter|g__Bacteroides.s__Bacteroides_stercoris	0.9661835749
+UniRef50_B0NMV2	0.9633911368
+UniRef50_B0NMV2|g__Bacteroides.s__Bacteroides_stercoris	0.9633911368
+UniRef50_C6XUQ9: N-acetylglucosamine-6-phosphate deacetylase	0.9633911368
+UniRef50_C6XUQ9: N-acetylglucosamine-6-phosphate deacetylase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9633911368
+UniRef50_R6JHS2	0.9624639076
+UniRef50_R6JHS2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9624639076
+UniRef50_R6APR2: TonB-dependent receptor	0.9606147935
+UniRef50_R6APR2: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9606147935
+UniRef50_Q8A351	0.9578544061
+UniRef50_Q8A351|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9578544061
+UniRef50_R5K7V2: Aminotransferase class I and II	0.9578544061
+UniRef50_R5K7V2: Aminotransferase class I and II|g__Bacteroides.s__Bacteroides_stercoris	0.9578544061
+UniRef50_D3QZF7: UDP-N-acetylglucosamine 2-epimerase	0.9551098376
+UniRef50_D3QZF7: UDP-N-acetylglucosamine 2-epimerase|g__Bacteroides.s__Bacteroides_stercoris	0.9551098376
+UniRef50_Q8A539	0.9523809524
+UniRef50_Q8A539|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9523809524
+UniRef50_Q8A5X7: Galactose-binding-like protein	0.9523809524
+UniRef50_Q8A5X7: Galactose-binding-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9523809524
+UniRef50_R6JCQ7	0.9523809524
+UniRef50_R6JCQ7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9523809524
+UniRef50_R7CTU0: Glycoside hydrolase family 15	0.9523809524
+UniRef50_R7CTU0: Glycoside hydrolase family 15|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9523809524
+UniRef50_R5JMV2	0.9517132877
+UniRef50_R5JMV2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4775549188
+UniRef50_R5JMV2|g__Bacteroides.s__Bacteroides_stercoris	0.4741583689
+UniRef50_K0CZ06: Glycosyl hydrolase	0.9496676163
+UniRef50_K0CZ06: Glycosyl hydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9496676163
+UniRef50_R5LPK8	0.9496676163
+UniRef50_R5LPK8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9496676163
+UniRef50_R5ETJ9	0.9469696970
+UniRef50_R5ETJ9|g__Bacteroides.s__Bacteroides_stercoris	0.9469696970
+UniRef50_R6JJS8	0.9469696970
+UniRef50_R6JJS8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9469696970
+UniRef50_W4UNV5: Protein translocase subunit SecA	0.9460737938
+UniRef50_W4UNV5: Protein translocase subunit SecA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9460737938
+UniRef50_R5MKR5: Concanavalin A-like lectin/glucanase	0.9442870633
+UniRef50_R5MKR5: Concanavalin A-like lectin/glucanase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9442870633
+UniRef50_R5UD95	0.9442870633
+UniRef50_R5UD95|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9442870633
+UniRef50_B1LE56: Cysteine desulfurase	0.9416195857
+UniRef50_B1LE56: Cysteine desulfurase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9416195857
+UniRef50_R7EVE0: L-serine ammonia-lyase	0.9416195857
+UniRef50_R7EVE0: L-serine ammonia-lyase|g__Bacteroides.s__Bacteroides_stercoris	0.9416195857
+UniRef50_Q8A3N6	0.9389671362
+UniRef50_Q8A3N6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9389671362
+UniRef50_Q8AAZ4: SusD homolog	0.9389671362
+UniRef50_Q8AAZ4: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9389671362
+UniRef50_R7EDB9: L-fucose:H+ symporter permease	0.9389671362
+UniRef50_R7EDB9: L-fucose:H+ symporter permease|g__Bacteroides.s__Bacteroides_stercoris	0.9389671362
+UniRef50_B0NP74	0.9363295880
+UniRef50_B0NP74|g__Bacteroides.s__Bacteroides_stercoris	0.9363295880
+UniRef50_R7E276: MbeB-like domain protein	0.9363295880
+UniRef50_R7E276: MbeB-like domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9363295880
+UniRef50_I1YR97: S-adenosylmethionine:tRNA ribosyltransferase-isomerase	0.9337068161
+UniRef50_I1YR97: S-adenosylmethionine:tRNA ribosyltransferase-isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9337068161
+UniRef50_W6PQ03: Membrane protein, putative	0.9319680666
+UniRef50_W6PQ03: Membrane protein, putative|g__Bacteroides.s__Bacteroides_stercoris	0.6218905473
+UniRef50_W6PQ03: Membrane protein, putative|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3100775194
+UniRef50_D4WJ09: Putative 3-deoxy-D-manno-octulosonic-acid transferase	0.9310986965
+UniRef50_D4WJ09: Putative 3-deoxy-D-manno-octulosonic-acid transferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9310986965
+UniRef50_P0AFF4: Nucleoside permease NupG	0.9310986965
+UniRef50_P0AFF4: Nucleoside permease NupG|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9310986965
+UniRef50_R7P669	0.9310986965
+UniRef50_R7P669|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9310986965
+UniRef50_Q89ZU2: Glycoside transferase family 4	0.9285051068
+UniRef50_Q89ZU2: Glycoside transferase family 4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9285051068
+UniRef50_R5S5U0: Glycosyltransferase group 1 family protein	0.9285051068
+UniRef50_R5S5U0: Glycosyltransferase group 1 family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9285051068
+UniRef50_R6V8L4	0.9285051068
+UniRef50_R6V8L4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9285051068
+UniRef50_D9RRZ7: HD domain protein	0.9259259259
+UniRef50_D9RRZ7: HD domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9259259259
+UniRef50_R6CU88	0.9210247275
+UniRef50_R6CU88|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9210247275
+UniRef50_I2EWF1: Peptidase M16 domain protein	0.9208103131
+UniRef50_I2EWF1: Peptidase M16 domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.9208103131
+UniRef50_R5NYX5: Sodium ion-translocating decarboxylase beta subunit	0.9208103131
+UniRef50_R5NYX5: Sodium ion-translocating decarboxylase beta subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9208103131
+UniRef50_R5U7R5	0.9208103131
+UniRef50_R5U7R5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9208103131
+UniRef50_R5UJ48	0.9208103131
+UniRef50_R5UJ48|g__Bacteroides.s__Bacteroides_stercoris	0.9208103131
+UniRef50_R6FJ75: Beta-N-acetylhexosaminidase	0.9195402299
+UniRef50_R6FJ75: Beta-N-acetylhexosaminidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9195402299
+UniRef50_K5BT09	0.9157509158
+UniRef50_K5BT09|g__Bacteroides.s__Bacteroides_stercoris	0.9157509158
+UniRef50_Q5L8L7: ATP-dependent Clp protease ATP-binding subunit ClpX	0.9132420091
+UniRef50_Q5L8L7: ATP-dependent Clp protease ATP-binding subunit ClpX|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9132420091
+UniRef50_R6US20	0.9107468124
+UniRef50_R6US20|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9107468124
+UniRef50_R7PBD0	0.9107468124
+UniRef50_R7PBD0|g__Bacteroides.s__Bacteroides_stercoris	0.9107468124
+UniRef50_R6XRD6: Alpha-1 2-mannosidase putative	0.9080613169
+UniRef50_R6XRD6: Alpha-1 2-mannosidase putative|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9080613169
+UniRef50_B2RLA8: Imidazolonepropionase	0.9057971014
+UniRef50_B2RLA8: Imidazolonepropionase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9057971014
+UniRef50_R5AQW0: Tetrahydrofolate synthase	0.9057971014
+UniRef50_R5AQW0: Tetrahydrofolate synthase|g__Bacteroides.s__Bacteroides_stercoris	0.9057971014
+UniRef50_D5EZC2: CBS/transporter associated domain protein	0.9033423668
+UniRef50_D5EZC2: CBS/transporter associated domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9033423668
+UniRef50_Q838L2: L-rhamnose isomerase	0.9033423668
+UniRef50_Q838L2: L-rhamnose isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9033423668
+UniRef50_R7JE67	0.9033423668
+UniRef50_R7JE67|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9033423668
+UniRef50_D5EVI1: GTPase HflX	0.9009009009
+UniRef50_D5EVI1: GTPase HflX|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9009009009
+UniRef50_Q5LGW9: Alpha-N-acetylgalactosaminidase	0.9009009009
+UniRef50_Q5LGW9: Alpha-N-acetylgalactosaminidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9009009009
+UniRef50_Q7MU77: Phosphoglycerate kinase	0.9009009009
+UniRef50_Q7MU77: Phosphoglycerate kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9009009009
+UniRef50_Q8A5G2: Transposase	0.9009009009
+UniRef50_Q8A5G2: Transposase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.9009009009
+UniRef50_Q64VY8: ABC transporter permease protein	0.8952551477
+UniRef50_Q64VY8: ABC transporter permease protein|g__Bacteroides.s__Bacteroides_stercoris	0.8952551477
+UniRef50_A6KY74: Two-component system sensor histidine kinase	0.8936550492
+UniRef50_A6KY74: Two-component system sensor histidine kinase|g__Bacteroides.s__Bacteroides_stercoris	0.8936550492
+UniRef50_R5K3I7: TonB-dependent Receptor Plug domain-containing protein	0.8928571429
+UniRef50_R5K3I7: TonB-dependent Receptor Plug domain-containing protein|g__Bacteroides.s__Bacteroides_stercoris	0.8928571429
+UniRef50_Q8A5M5	0.8888888889
+UniRef50_Q8A5M5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8888888889
+UniRef50_Q8ZFX5: Histidinol dehydrogenase	0.8818342152
+UniRef50_Q8ZFX5: Histidinol dehydrogenase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8818342152
+UniRef50_R7J412: Pyruvate-flavodoxin oxidoreductase	0.8802816901
+UniRef50_R7J412: Pyruvate-flavodoxin oxidoreductase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8802816901
+UniRef50_B2GKX1: O-acetylhomoserine (Thiol)-lyase	0.8795074758
+UniRef50_B2GKX1: O-acetylhomoserine (Thiol)-lyase|g__Bacteroides.s__Bacteroides_stercoris	0.8795074758
+UniRef50_D3R5Q5: O-acetyl-L-homoserine sulfhydrolase	0.8795074758
+UniRef50_D3R5Q5: O-acetyl-L-homoserine sulfhydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8795074758
+UniRef50_Q8A285	0.8795074758
+UniRef50_Q8A285|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8795074758
+UniRef50_D6D518: Myo-inositol-1-phosphate synthase	0.8771929825
+UniRef50_D6D518: Myo-inositol-1-phosphate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8771929825
+UniRef50_R5FDQ5	0.8771929825
+UniRef50_R5FDQ5|g__Bacteroides.s__Bacteroides_stercoris	0.8771929825
+UniRef50_R6V5M5: Radical SAM domain protein	0.8771929825
+UniRef50_R6V5M5: Radical SAM domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.8771929825
+UniRef50_R7NU49: Aspartokinase I-homoserine dehydrogenase	0.8760402979
+UniRef50_R7NU49: Aspartokinase I-homoserine dehydrogenase|g__Bacteroides.s__Bacteroides_stercoris	0.8760402979
+UniRef50_Q8A2T6: S-adenosylmethionine synthase	0.8748906387
+UniRef50_Q8A2T6: S-adenosylmethionine synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8748906387
+UniRef50_Q8A307	0.8748906387
+UniRef50_Q8A307|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8748906387
+UniRef50_R5PHV4	0.8748906387
+UniRef50_R5PHV4|g__Bacteroides.s__Bacteroides_stercoris	0.8748906387
+UniRef50_R5S220	0.8748906387
+UniRef50_R5S220|g__Bacteroides.s__Bacteroides_stercoris	0.8748906387
+UniRef50_R6L8W2: BNR/Asp-box repeat protein	0.8748906387
+UniRef50_R6L8W2: BNR/Asp-box repeat protein|g__Bacteroides.s__Bacteroides_stercoris	0.8748906387
+UniRef50_R7E0Q9	0.8748906387
+UniRef50_R7E0Q9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8748906387
+UniRef50_R7GUK0: DEAD/DEAH box helicase	0.8748906387
+UniRef50_R7GUK0: DEAD/DEAH box helicase|g__Bacteroides.s__Bacteroides_stercoris	0.8748906387
+UniRef50_D5ESJ2: Inositol-3-phosphate synthase	0.8726003490
+UniRef50_D5ESJ2: Inositol-3-phosphate synthase|g__Bacteroides.s__Bacteroides_stercoris	0.8726003490
+UniRef50_D5EV84: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase	0.8703220191
+UniRef50_D5EV84: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8703220191
+UniRef50_R6B579: Galacturan 1 4-alpha-galacturonidase	0.8703220191
+UniRef50_R6B579: Galacturan 1 4-alpha-galacturonidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8703220191
+UniRef50_R6YIA5: Peptidase M23 family	0.8703220191
+UniRef50_R6YIA5: Peptidase M23 family|g__Bacteroides.s__Bacteroides_stercoris	0.8703220191
+UniRef50_R7EXU7: Ribosomal protein S12 methylthiotransferase RimO	0.8703220191
+UniRef50_R7EXU7: Ribosomal protein S12 methylthiotransferase RimO|g__Bacteroides.s__Bacteroides_stercoris	0.8703220191
+UniRef50_Q7MUW1: UDP-N-acetylglucosamine 1-carboxyvinyltransferase	0.8658008658
+UniRef50_Q7MUW1: UDP-N-acetylglucosamine 1-carboxyvinyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8658008658
+UniRef50_A6KY55: Conserved protein found in conjugate transposon	0.8635578584
+UniRef50_A6KY55: Conserved protein found in conjugate transposon|g__Bacteroides.s__Bacteroides_stercoris	0.8635578584
+UniRef50_R5CLY4: MATE efflux family protein	0.8635578584
+UniRef50_R5CLY4: MATE efflux family protein|g__Bacteroides.s__Bacteroides_stercoris	0.8635578584
+UniRef50_R6UXK7	0.8635578584
+UniRef50_R6UXK7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8635578584
+UniRef50_R6XTA9: Transporter major facilitator family protein	0.8613264427
+UniRef50_R6XTA9: Transporter major facilitator family protein|g__Bacteroides.s__Bacteroides_stercoris	0.8613264427
+UniRef50_R7NJF0: Cell division protein FtsZ	0.8591065292
+UniRef50_R7NJF0: Cell division protein FtsZ|g__Bacteroides.s__Bacteroides_stercoris	0.8591065292
+UniRef50_R6DFM3: Aspartokinase	0.8568980291
+UniRef50_R6DFM3: Aspartokinase|g__Bacteroides.s__Bacteroides_stercoris	0.8568980291
+UniRef50_R6FS39: Hsp90-like protein	0.8568980291
+UniRef50_R6FS39: Hsp90-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8568980291
+UniRef50_K0WJ22: Uracil-xanthine permease/xanthine permease	0.8547008547
+UniRef50_K0WJ22: Uracil-xanthine permease/xanthine permease|g__Bacteroides.s__Bacteroides_stercoris	0.8547008547
+UniRef50_R5TZY1: Ribonuclease BN	0.8547008547
+UniRef50_R5TZY1: Ribonuclease BN|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8547008547
+UniRef50_R6VND8	0.8547008547
+UniRef50_R6VND8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8547008547
+UniRef50_R5I7I3	0.8525149190
+UniRef50_R5I7I3|g__Bacteroides.s__Bacteroides_stercoris	0.8525149190
+UniRef50_E6SWU3: DUF234 DEXX-box ATPase	0.8503401361
+UniRef50_E6SWU3: DUF234 DEXX-box ATPase|g__Bacteroides.s__Bacteroides_stercoris	0.8503401361
+UniRef50_Q8REJ9: ATPase	0.8503401361
+UniRef50_Q8REJ9: ATPase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8503401361
+UniRef50_F4LMG6: Phosphoenolpyruvate phosphomutase	0.8474576271
+UniRef50_F4LMG6: Phosphoenolpyruvate phosphomutase|g__Bacteroides.s__Bacteroides_stercoris	0.8474576271
+UniRef50_F0QZ62	0.8460236887
+UniRef50_F0QZ62|g__Bacteroides.s__Bacteroides_stercoris	0.8460236887
+UniRef50_R7KWB0	0.8460236887
+UniRef50_R7KWB0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8460236887
+UniRef50_Q8A589	0.8438818565
+UniRef50_Q8A589|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8438818565
+UniRef50_R6DK68	0.8438818565
+UniRef50_R6DK68|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8438818565
+UniRef50_R5SQC5	0.8428271256
+UniRef50_R5SQC5|g__Bacteroides.s__Bacteroides_stercoris	0.4230118443
+UniRef50_R5SQC5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4198152813
+UniRef50_Q04IA2: Glucose-6-phosphate isomerase	0.8417508418
+UniRef50_Q04IA2: Glucose-6-phosphate isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8417508418
+UniRef50_R6M5X0	0.8417508418
+UniRef50_R6M5X0|g__Bacteroides.s__Bacteroides_stercoris	0.8417508418
+UniRef50_R5JQA5	0.8396305626
+UniRef50_R5JQA5|g__Bacteroides.s__Bacteroides_stercoris	0.8396305626
+UniRef50_R5Y371	0.8396305626
+UniRef50_R5Y371|g__Bacteroides.s__Bacteroides_stercoris	0.8396305626
+UniRef50_R7EI38: Magnesium transporter	0.8396305626
+UniRef50_R7EI38: Magnesium transporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8396305626
+UniRef50_D6D118: F5/8 type C domain	0.8375209380
+UniRef50_D6D118: F5/8 type C domain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8375209380
+UniRef50_R5VG84: Protein translocase subunit SecY	0.8375209380
+UniRef50_R5VG84: Protein translocase subunit SecY|g__Bacteroides.s__Bacteroides_stercoris	0.8375209380
+UniRef50_R6A0Z5: FeS assembly protein SufD	0.8375209380
+UniRef50_R6A0Z5: FeS assembly protein SufD|g__Bacteroides.s__Bacteroides_stercoris	0.8375209380
+UniRef50_R6XFB4	0.8375209380
+UniRef50_R6XFB4|g__Bacteroides.s__Bacteroides_stercoris	0.8375209380
+UniRef50_T2KHY1: Ribonucleoside-diphosphate reductase	0.8375209380
+UniRef50_T2KHY1: Ribonucleoside-diphosphate reductase|g__Bacteroides.s__Bacteroides_stercoris	0.4187604690
+UniRef50_T2KHY1: Ribonucleoside-diphosphate reductase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4187604690
+UniRef50_R5K6Q7	0.8354218881
+UniRef50_R5K6Q7|g__Bacteroides.s__Bacteroides_stercoris	0.8354218881
+UniRef50_R5PHZ4: Outer membrane efflux protein	0.8354218881
+UniRef50_R5PHZ4: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8354218881
+UniRef50_R6LNE3: Outer membrane efflux protein	0.8354218881
+UniRef50_R6LNE3: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8354218881
+UniRef50_F4C8Z9	0.8343763037
+UniRef50_F4C8Z9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8343763037
+UniRef50_R6JSE0: HRDC domain protein	0.8343763037
+UniRef50_R6JSE0: HRDC domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8343763037
+UniRef50_Q89ZD9	0.8333333333
+UniRef50_Q89ZD9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8333333333
+UniRef50_R6C179: Bacterial extracellular solute-binding protein	0.8333333333
+UniRef50_R6C179: Bacterial extracellular solute-binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8333333333
+UniRef50_R6YBT5: Gliding motility-associated protein GldE	0.8312551953
+UniRef50_R6YBT5: Gliding motility-associated protein GldE|g__Bacteroides.s__Bacteroides_stercoris	0.8312551953
+UniRef50_W0ERH5: Conjugate transposon protein	0.8312551953
+UniRef50_W0ERH5: Conjugate transposon protein|g__Bacteroides.s__Bacteroides_stercoris	0.8312551953
+UniRef50_R5NYT6: Hydrophobic domain protein	0.8291873964
+UniRef50_R5NYT6: Hydrophobic domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8291873964
+UniRef50_R6E1S9	0.8291873964
+UniRef50_R6E1S9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8291873964
+UniRef50_A4X5J8: 4-diphosphocytidyl-2C-methyl-D-erythritol synthase	0.8250825083
+UniRef50_A4X5J8: 4-diphosphocytidyl-2C-methyl-D-erythritol synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8250825083
+UniRef50_R6E1I6	0.8250825083
+UniRef50_R6E1I6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8250825083
+UniRef50_Q64QS2: Histidine--tRNA ligase	0.8230452675
+UniRef50_Q64QS2: Histidine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8230452675
+UniRef50_R5U378	0.8230452675
+UniRef50_R5U378|g__Bacteroides.s__Bacteroides_stercoris	0.8230452675
+UniRef50_R6K5T5: Arylsulfatase	0.8210180624
+UniRef50_R6K5T5: Arylsulfatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8210180624
+UniRef50_E6WX55: Xylose isomerase	0.8190008190
+UniRef50_E6WX55: Xylose isomerase|g__Bacteroides.s__Bacteroides_stercoris	0.8190008190
+UniRef50_R5JNL0	0.8190008190
+UniRef50_R5JNL0|g__Bacteroides.s__Bacteroides_stercoris	0.8190008190
+UniRef50_R6M7U0: Transporter major facilitator family protein	0.8190008190
+UniRef50_R6M7U0: Transporter major facilitator family protein|g__Bacteroides.s__Bacteroides_stercoris	0.8190008190
+UniRef50_R5AK03	0.8179959100
+UniRef50_R5AK03|g__Bacteroides.s__Bacteroides_stercoris	0.8179959100
+UniRef50_I1YT44: DNA mismatch repair protein MutS	0.8155191041
+UniRef50_I1YT44: DNA mismatch repair protein MutS|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4100041000
+UniRef50_I1YT44: DNA mismatch repair protein MutS|g__Bacteroides.s__Bacteroides_stercoris	0.4055150041
+UniRef50_D5H9Z4: Sigma-54 dependent DNA-binding response regulator, Fis family	0.8149959250
+UniRef50_D5H9Z4: Sigma-54 dependent DNA-binding response regulator, Fis family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8149959250
+UniRef50_I9SKL2	0.8120178644
+UniRef50_I9SKL2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8120178644
+UniRef50_R7EVE7	0.8110300081
+UniRef50_R7EVE7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8110300081
+UniRef50_Q8A7K8: Replicative DNA helicase	0.8090614887
+UniRef50_Q8A7K8: Replicative DNA helicase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8090614887
+UniRef50_R5RIY3	0.8090614887
+UniRef50_R5RIY3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8090614887
+UniRef50_R6AKS2	0.8090614887
+UniRef50_R6AKS2|g__Bacteroides.s__Bacteroides_stercoris	0.8090614887
+UniRef50_A6L2B0: Glycoside hydrolase family 28	0.8071025020
+UniRef50_A6L2B0: Glycoside hydrolase family 28|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_D7I9G0: F5/8 type C domain-containing protein	0.8071025020
+UniRef50_D7I9G0: F5/8 type C domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_Q89YJ1	0.8071025020
+UniRef50_Q89YJ1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_R5EPL7	0.8071025020
+UniRef50_R5EPL7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_R5TX52: Major facilitator superfamily MFS_1	0.8071025020
+UniRef50_R5TX52: Major facilitator superfamily MFS_1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_R6ALV2: Transglycosylase SLT domain protein	0.8071025020
+UniRef50_R6ALV2: Transglycosylase SLT domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8071025020
+UniRef50_F9D499: Chromosomal replication initiator protein DnaA	0.8051529791
+UniRef50_F9D499: Chromosomal replication initiator protein DnaA|g__Bacteroides.s__Bacteroides_stercoris	0.8051529791
+UniRef50_Q7UIA7: 3-isopropylmalate dehydratase large subunit	0.8032128514
+UniRef50_Q7UIA7: 3-isopropylmalate dehydratase large subunit|g__Bacteroides.s__Bacteroides_stercoris	0.8032128514
+UniRef50_D6D1E1: Predicted unsaturated glucuronyl hydrolase involved in regulation of bacterial surface properties, and related proteins	0.8012820513
+UniRef50_D6D1E1: Predicted unsaturated glucuronyl hydrolase involved in regulation of bacterial surface properties, and related proteins|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.8012820513
+UniRef50_R5K6U5: Peptidase C1-like family protein	0.8012820513
+UniRef50_R5K6U5: Peptidase C1-like family protein|g__Bacteroides.s__Bacteroides_stercoris	0.8012820513
+UniRef50_R5Y5Y4	0.7993605116
+UniRef50_R5Y5Y4|g__Bacteroides.s__Bacteroides_stercoris	0.7993605116
+UniRef50_A6LEU2: UDP-N-acetylmuramate--L-alanine ligase	0.7974481659
+UniRef50_A6LEU2: UDP-N-acetylmuramate--L-alanine ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7974481659
+UniRef50_D6D175: GDSL-like Lipase/Acylhydrolase	0.7974481659
+UniRef50_D6D175: GDSL-like Lipase/Acylhydrolase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7974481659
+UniRef50_P58696: Asparagine--tRNA ligase	0.7974481659
+UniRef50_P58696: Asparagine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7974481659
+UniRef50_R5JPW7: TolC family type I secretion outer membrane protein	0.7974481659
+UniRef50_R5JPW7: TolC family type I secretion outer membrane protein|g__Bacteroides.s__Bacteroides_stercoris	0.7974481659
+UniRef50_R6MHI2: Mobilization protein	0.7974481659
+UniRef50_R6MHI2: Mobilization protein|g__Bacteroides.s__Bacteroides_stercoris	0.7974481659
+UniRef50_R6B8Z4: Response regulator receiver domain protein	0.7970652674
+UniRef50_R6B8Z4: Response regulator receiver domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.7970652674
+UniRef50_Q0AVI1	0.7955449483
+UniRef50_Q0AVI1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7955449483
+UniRef50_R5PCA6	0.7936507937
+UniRef50_R5PCA6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7936507937
+UniRef50_Q8A2K7	0.7917656374
+UniRef50_Q8A2K7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7917656374
+UniRef50_Q8A790: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)	0.7907354484
+UniRef50_Q8A790: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7907354484
+UniRef50_R5N6E0: Arabinose-proton symporter	0.7898894155
+UniRef50_R5N6E0: Arabinose-proton symporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7898894155
+UniRef50_S3YU07	0.7898894155
+UniRef50_S3YU07|g__Bacteroides.s__Bacteroides_stercoris	0.7898894155
+UniRef50_Q89Z59: Probable type I restriction enzyme BthVORF4518P M protein	0.7880220646
+UniRef50_Q89Z59: Probable type I restriction enzyme BthVORF4518P M protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7880220646
+UniRef50_B0NU77	0.7861635220
+UniRef50_B0NU77|g__Bacteroides.s__Bacteroides_stercoris	0.7861635220
+UniRef50_D4JAQ7	0.7861635220
+UniRef50_D4JAQ7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7861635220
+UniRef50_R7KQQ4: Sulfatase family protein	0.7861635220
+UniRef50_R7KQQ4: Sulfatase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7861635220
+UniRef50_Q8A1R2: Sialic acid-specific 9-O-acetylesterase	0.7843137255
+UniRef50_Q8A1R2: Sialic acid-specific 9-O-acetylesterase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7843137255
+UniRef50_R6B7R5	0.7843137255
+UniRef50_R6B7R5|g__Bacteroides.s__Bacteroides_stercoris	0.7843137255
+UniRef50_R6LCG3	0.7810977100
+UniRef50_R6LCG3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7810977100
+UniRef50_R5C5A0: Tetratricopeptide repeat protein	0.7806401249
+UniRef50_R5C5A0: Tetratricopeptide repeat protein|g__Bacteroides.s__Bacteroides_stercoris	0.7806401249
+UniRef50_R6KD20	0.7806401249
+UniRef50_R6KD20|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7806401249
+UniRef50_Q9HTD7: Aspartate ammonia-lyase	0.7788161994
+UniRef50_Q9HTD7: Aspartate ammonia-lyase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7788161994
+UniRef50_R6CDJ5	0.7788161994
+UniRef50_R6CDJ5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7788161994
+UniRef50_D6D584: Arylsulfatase A and related enzymes	0.7716049383
+UniRef50_D6D584: Arylsulfatase A and related enzymes|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7716049383
+UniRef50_R6CMZ9	0.7716049383
+UniRef50_R6CMZ9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7716049383
+UniRef50_D3ICC6	0.7698229407
+UniRef50_D3ICC6|g__Bacteroides.s__Bacteroides_stercoris	0.7698229407
+UniRef50_Q7MWM7: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase	0.7698229407
+UniRef50_Q7MWM7: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7698229407
+UniRef50_Q8A3G2: Virulence-associated protein E-like protein	0.7698229407
+UniRef50_Q8A3G2: Virulence-associated protein E-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7698229407
+UniRef50_R5C2D3	0.7698229407
+UniRef50_R5C2D3|g__Bacteroides.s__Bacteroides_stercoris	0.7698229407
+UniRef50_R6MJ95: Polysaccharide biosynthesis protein	0.7698229407
+UniRef50_R6MJ95: Polysaccharide biosynthesis protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7698229407
+UniRef50_R5GUG1	0.7680491551
+UniRef50_R5GUG1|g__Bacteroides.s__Bacteroides_stercoris	0.7680491551
+UniRef50_A6L4J4: Na+/solute symporter	0.7662835249
+UniRef50_A6L4J4: Na+/solute symporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7662835249
+UniRef50_R5RSK0	0.7662835249
+UniRef50_R5RSK0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7662835249
+UniRef50_G8UQN8: Xaa-His dipeptidase	0.7645259939
+UniRef50_G8UQN8: Xaa-His dipeptidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7645259939
+UniRef50_R6XBT3: Pyruvate kinase	0.7645259939
+UniRef50_R6XBT3: Pyruvate kinase|g__Bacteroides.s__Bacteroides_stercoris	0.7645259939
+UniRef50_R5MS47: TonB-dependent receptor	0.7636502482
+UniRef50_R5MS47: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_stercoris	0.7636502482
+UniRef50_Q8A7B0: Aminoacyl-histidine dipeptidase	0.7627765065
+UniRef50_Q8A7B0: Aminoacyl-histidine dipeptidase|g__Bacteroides.s__Bacteroides_stercoris	0.7627765065
+UniRef50_R5JLZ4	0.7610350076
+UniRef50_R5JLZ4|g__Bacteroides.s__Bacteroides_stercoris	0.7610350076
+UniRef50_R7H225	0.7610350076
+UniRef50_R7H225|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7610350076
+UniRef50_R6ADH8	0.7593014427
+UniRef50_R6ADH8|g__Bacteroides.s__Bacteroides_stercoris	0.7593014427
+UniRef50_D6D6G8: SusD family	0.7575757576
+UniRef50_D6D6G8: SusD family|g__Bacteroides.s__Bacteroides_stercoris	0.7575757576
+UniRef50_R6D0G3	0.7575757576
+UniRef50_R6D0G3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7575757576
+UniRef50_R7DNV4: Outer membrane efflux protein	0.7558578987
+UniRef50_R7DNV4: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7558578987
+UniRef50_R5J8S8	0.7552870091
+UniRef50_R5J8S8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7552870091
+UniRef50_Q8A8Y7: Fibronectin, type III-like fold	0.7541478130
+UniRef50_Q8A8Y7: Fibronectin, type III-like fold|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7541478130
+UniRef50_R6DY62: Tetrahydrofolate synthase	0.7541478130
+UniRef50_R6DY62: Tetrahydrofolate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7541478130
+UniRef50_R6JRP7: 6-phosphogluconate dehydrogenase, decarboxylating	0.7541478130
+UniRef50_R6JRP7: 6-phosphogluconate dehydrogenase, decarboxylating|g__Bacteroides.s__Bacteroides_stercoris	0.7541478130
+UniRef50_R7KYE7	0.7541478130
+UniRef50_R7KYE7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7541478130
+UniRef50_Q8A551: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)	0.7530120482
+UniRef50_Q8A551: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7530120482
+UniRef50_A6L4U5: Altronate oxidoreductase	0.7524454477
+UniRef50_A6L4U5: Altronate oxidoreductase|g__Bacteroides.s__Bacteroides_stercoris	0.7524454477
+UniRef50_R5JMK7	0.7507507508
+UniRef50_R5JMK7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7507507508
+UniRef50_D6D0L5: Na+/proline symporter	0.7473841555
+UniRef50_D6D0L5: Na+/proline symporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7473841555
+UniRef50_R7DFF4	0.7473841555
+UniRef50_R7DFF4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7473841555
+UniRef50_R5Y1M5: Excinuclease ABC subunit A	0.7465472191
+UniRef50_R5Y1M5: Excinuclease ABC subunit A|g__Bacteroides.s__Bacteroides_stercoris	0.7465472191
+UniRef50_H8KPI4: RagB/SusD family protein	0.7457121551
+UniRef50_H8KPI4: RagB/SusD family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7457121551
+UniRef50_R5AML8: Pseudouridine synthase	0.7457121551
+UniRef50_R5AML8: Pseudouridine synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7457121551
+UniRef50_G8UNX0: Outer membrane efflux protein	0.7423904974
+UniRef50_G8UNX0: Outer membrane efflux protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7423904974
+UniRef50_D6CWM9: Outer membrane cobalamin receptor protein	0.7407407407
+UniRef50_D6CWM9: Outer membrane cobalamin receptor protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7407407407
+UniRef50_P52043: Propionyl-CoA:succinate CoA transferase	0.7407407407
+UniRef50_P52043: Propionyl-CoA:succinate CoA transferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7407407407
+UniRef50_Q8A8I5	0.7390983001
+UniRef50_Q8A8I5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7390983001
+UniRef50_R6KDW2	0.7358351729
+UniRef50_R6KDW2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7358351729
+UniRef50_R5Q0I7: GH3 auxin-responsive promoter	0.7342143906
+UniRef50_R5Q0I7: GH3 auxin-responsive promoter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7342143906
+UniRef50_R6M6C5: Bacterial sugar transferase	0.7342143906
+UniRef50_R6M6C5: Bacterial sugar transferase|g__Bacteroides.s__Bacteroides_stercoris	0.7342143906
+UniRef50_R6X0K5: ABC transporter ATP-binding protein	0.7342143906
+UniRef50_R6X0K5: ABC transporter ATP-binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7342143906
+UniRef50_A6L050: 2,3-bisphosphoglycerate-independent phosphoglycerate mutase	0.7326007326
+UniRef50_A6L050: 2,3-bisphosphoglycerate-independent phosphoglycerate mutase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7326007326
+UniRef50_F3ZUL5: Amino acid/peptide transporter	0.7326007326
+UniRef50_F3ZUL5: Amino acid/peptide transporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7326007326
+UniRef50_Q64PR3	0.7326007326
+UniRef50_Q64PR3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7326007326
+UniRef50_R6CT82	0.7315288954
+UniRef50_R6CT82|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7315288954
+UniRef50_A6L4L7: ATP synthase subunit beta	0.7309941520
+UniRef50_A6L4L7: ATP synthase subunit beta|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7309941520
+UniRef50_R6V1Q7	0.7293946025
+UniRef50_R6V1Q7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7293946025
+UniRef50_X5DW04: Membrane protein	0.7293946025
+UniRef50_X5DW04: Membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7293946025
+UniRef50_D2QFV1: Phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase	0.7278020378
+UniRef50_D2QFV1: Phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase|g__Bacteroides.s__Bacteroides_stercoris	0.7278020378
+UniRef50_Q4FMW8: GMP synthase [glutamine-hydrolyzing]	0.7278020378
+UniRef50_Q4FMW8: GMP synthase [glutamine-hydrolyzing]|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7278020378
+UniRef50_Q8A3V7	0.7278020378
+UniRef50_Q8A3V7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7278020378
+UniRef50_R6W503	0.7278020378
+UniRef50_R6W503|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7278020378
+UniRef50_D7IHX5: Endo-beta-N-acetylglucosaminidase F1	0.7262164125
+UniRef50_D7IHX5: Endo-beta-N-acetylglucosaminidase F1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7262164125
+UniRef50_R7KFY3	0.7262164125
+UniRef50_R7KFY3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7262164125
+UniRef50_R6UPJ0: F5/8 type C domain-containing protein	0.7254261879
+UniRef50_R6UPJ0: F5/8 type C domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7254261879
+UniRef50_A6L2R5: L-arabinose isomerase	0.7246376812
+UniRef50_A6L2R5: L-arabinose isomerase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7246376812
+UniRef50_V4ISH8	0.7246376812
+UniRef50_V4ISH8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7246376812
+UniRef50_R5NGW5: Hydrolase carbon-nitrogen family	0.7199424046
+UniRef50_R5NGW5: Hydrolase carbon-nitrogen family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7199424046
+UniRef50_B2RH83: Glycine--tRNA ligase	0.7183908046
+UniRef50_B2RH83: Glycine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7183908046
+UniRef50_D6CWY9: Beta-xylosidase	0.7183908046
+UniRef50_D6CWY9: Beta-xylosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7183908046
+UniRef50_Q08408: Sensor protein RprX	0.7183908046
+UniRef50_Q08408: Sensor protein RprX|g__Bacteroides.s__Bacteroides_stercoris	0.7183908046
+UniRef50_R7KSU0	0.7183908046
+UniRef50_R7KSU0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7183908046
+UniRef50_R6X4P3	0.7137758744
+UniRef50_R6X4P3|g__Bacteroides.s__Bacteroides_stercoris	0.7137758744
+UniRef50_R6KNY1	0.7132667618
+UniRef50_R6KNY1|g__Bacteroides.s__Bacteroides_stercoris	0.7132667618
+UniRef50_R7NW91	0.7122507123
+UniRef50_R7NW91|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7122507123
+UniRef50_R6TBS5	0.7107320540
+UniRef50_R6TBS5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7107320540
+UniRef50_R6RRB5	0.7093241623
+UniRef50_R6RRB5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7093241623
+UniRef50_R7NXF1: Beta-hexosaminidase	0.7092198582
+UniRef50_R7NXF1: Beta-hexosaminidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7092198582
+UniRef50_Q64YL3	0.7077140835
+UniRef50_Q64YL3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7077140835
+UniRef50_R5AL42	0.7077140835
+UniRef50_R5AL42|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7077140835
+UniRef50_R5LZJ6	0.7077140835
+UniRef50_R5LZJ6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7077140835
+UniRef50_R6UUT6: Ferredoxin-type protein	0.7062146893
+UniRef50_R6UUT6: Ferredoxin-type protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7062146893
+UniRef50_A0A016KJM6: Type I restriction modification DNA specificity domain protein	0.7032348805
+UniRef50_A0A016KJM6: Type I restriction modification DNA specificity domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7032348805
+UniRef50_F9ZBC6: Transposase	0.7032348805
+UniRef50_F9ZBC6: Transposase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7032348805
+UniRef50_Q8A348: Arylsulfatase (Aryl-sulfate sulphohydrolase)	0.7032348805
+UniRef50_Q8A348: Arylsulfatase (Aryl-sulfate sulphohydrolase)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7032348805
+UniRef50_R6JLJ9: O-Glycosyl hydrolase family 30	0.7032348805
+UniRef50_R6JLJ9: O-Glycosyl hydrolase family 30|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7032348805
+UniRef50_I2EPJ9: Peptide chain release factor 3	0.7017543860
+UniRef50_I2EPJ9: Peptide chain release factor 3|g__Bacteroides.s__Bacteroides_stercoris	0.7017543860
+UniRef50_R5JR86	0.7017543860
+UniRef50_R5JR86|g__Bacteroides.s__Bacteroides_stercoris	0.7017543860
+UniRef50_R6CDM8: Type I phosphodiesterase / nucleotide pyrophosphatase	0.7017543860
+UniRef50_R6CDM8: Type I phosphodiesterase / nucleotide pyrophosphatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7017543860
+UniRef50_R6L771: Conserved domain protein	0.7017543860
+UniRef50_R6L771: Conserved domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.7017543860
+UniRef50_R7DI90: Rne/Rng family ribonuclease	0.7017543860
+UniRef50_R7DI90: Rne/Rng family ribonuclease|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7017543860
+UniRef50_R7EFC2	0.7017543860
+UniRef50_R7EFC2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7017543860
+UniRef50_Q8AB43: SusC homolog	0.7003758868
+UniRef50_Q8AB43: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7003758868
+UniRef50_R7KLE0	0.7002801120
+UniRef50_R7KLE0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.7002801120
+UniRef50_R5NZJ0: Export membrane protein SecD	0.6995452956
+UniRef50_R5NZJ0: Export membrane protein SecD|g__Bacteroides.s__Bacteroides_stercoris	0.6995452956
+UniRef50_Q8A8X8: SusD homolog	0.6973500697
+UniRef50_Q8A8X8: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6973500697
+UniRef50_R5CQ73: RND transporter HAE1/HME family permease protein	0.6937218176
+UniRef50_R5CQ73: RND transporter HAE1/HME family permease protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6937218176
+UniRef50_R6S9D4: Indolepyruvate oxidoreductase subunit IorA	0.6930006930
+UniRef50_R6S9D4: Indolepyruvate oxidoreductase subunit IorA|g__Bacteroides.s__Bacteroides_stercoris	0.6930006930
+UniRef50_R6DQP6	0.6915629322
+UniRef50_R6DQP6|g__Bacteroides.s__Bacteroides_stercoris	0.6915629322
+UniRef50_R6VM63: SusD homolog	0.6915629322
+UniRef50_R6VM63: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6915629322
+UniRef50_R6YXC4: PSP1 C-terminal domain protein	0.6915629322
+UniRef50_R6YXC4: PSP1 C-terminal domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6915629322
+UniRef50_I3YIX4	0.6910850035
+UniRef50_I3YIX4|g__Bacteroides.s__Bacteroides_stercoris	0.6910850035
+UniRef50_R6LNW7: SusD family protein	0.6901311249
+UniRef50_R6LNW7: SusD family protein|g__Bacteroides.s__Bacteroides_stercoris	0.6901311249
+UniRef50_R7KS33	0.6872852234
+UniRef50_R7KS33|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6872852234
+UniRef50_R5RWB9	0.6858710562
+UniRef50_R5RWB9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6858710562
+UniRef50_R7DH85	0.6858710562
+UniRef50_R7DH85|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6858710562
+UniRef50_E6SRW3: Beta-N-acetylhexosaminidase	0.6844626968
+UniRef50_E6SRW3: Beta-N-acetylhexosaminidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6844626968
+UniRef50_Q8A0F6: NADH-quinone oxidoreductase subunit C/D	0.6844626968
+UniRef50_Q8A0F6: NADH-quinone oxidoreductase subunit C/D|g__Bacteroides.s__Bacteroides_stercoris	0.6844626968
+UniRef50_Q8A1R5	0.6844626968
+UniRef50_Q8A1R5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6844626968
+UniRef50_R6LLK0	0.6844626968
+UniRef50_R6LLK0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6844626968
+UniRef50_Q8UEY5: CTP synthase	0.6830601093
+UniRef50_Q8UEY5: CTP synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6830601093
+UniRef50_R7CUF7	0.6830601093
+UniRef50_R7CUF7|g__Bacteroides.s__Bacteroides_stercoris	0.6830601093
+UniRef50_Q89ZV4: SusC homolog	0.6802721088
+UniRef50_Q89ZV4: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6802721088
+UniRef50_R6DIC5	0.6775067751
+UniRef50_R6DIC5|g__Bacteroides.s__Bacteroides_stercoris	0.6775067751
+UniRef50_R6DAL3	0.6761325220
+UniRef50_R6DAL3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6761325220
+UniRef50_P31206: Sialidase	0.6734006734
+UniRef50_P31206: Sialidase|g__Bacteroides.s__Bacteroides_stercoris	0.6734006734
+UniRef50_R5AW16: Hydrophobe/amphiphile efflux-1 (HAE1) family RND transporter	0.6734006734
+UniRef50_R5AW16: Hydrophobe/amphiphile efflux-1 (HAE1) family RND transporter|g__Bacteroides.s__Bacteroides_stercoris	0.6734006734
+UniRef50_R6XVC7: SusC/RagA family TonB-linked outer membrane protein	0.6734006734
+UniRef50_R6XVC7: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6734006734
+UniRef50_G8UMR7: Prevent-host-death family protein	0.6720430108
+UniRef50_G8UMR7: Prevent-host-death family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6720430108
+UniRef50_R5PJX9	0.6720430108
+UniRef50_R5PJX9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6720430108
+UniRef50_A0A015TE87: TonB-linked outer membrane , SusC/RagA family protein (Fragment)	0.6713662303
+UniRef50_A0A015TE87: TonB-linked outer membrane , SusC/RagA family protein (Fragment)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6713662303
+UniRef50_R7P910: Heavy metal efflux pump CzcA family	0.6713662303
+UniRef50_R7P910: Heavy metal efflux pump CzcA family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6713662303
+UniRef50_R5CDQ7	0.6706908115
+UniRef50_R5CDQ7|g__Bacteroides.s__Bacteroides_stercoris	0.6706908115
+UniRef50_R6JBQ0	0.6700167504
+UniRef50_R6JBQ0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6700167504
+UniRef50_R5C9I8: Pseudouridine synthase	0.6693440428
+UniRef50_R5C9I8: Pseudouridine synthase|g__Bacteroides.s__Bacteroides_stercoris	0.6693440428
+UniRef50_R6VRL5	0.6693440428
+UniRef50_R6VRL5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6693440428
+UniRef50_E1WVX1	0.6673340007
+UniRef50_E1WVX1|g__Bacteroides.s__Bacteroides_stercoris	0.6673340007
+UniRef50_Q8A432	0.6666666667
+UniRef50_Q8A432|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6666666667
+UniRef50_R6KQB3	0.6653359947
+UniRef50_R6KQB3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6653359947
+UniRef50_R5RRH8	0.6652306974
+UniRef50_R5RRH8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6652306974
+UniRef50_R7E8U3: Heavy metal efflux pump CzcA family	0.6646726487
+UniRef50_R7E8U3: Heavy metal efflux pump CzcA family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6646726487
+UniRef50_F4BY74: Acyl-coenzyme A synthetase	0.6640106242
+UniRef50_F4BY74: Acyl-coenzyme A synthetase|g__Bacteroides.s__Bacteroides_stercoris	0.6640106242
+UniRef50_Q8A5X9: SusC homolog	0.6640106242
+UniRef50_Q8A5X9: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6640106242
+UniRef50_A6KZP1: Flotillin-like protein	0.6626905235
+UniRef50_A6KZP1: Flotillin-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6626905235
+UniRef50_F4L7M9: RNA-directed DNA polymerase (Reverse transcriptase)	0.6626905235
+UniRef50_F4L7M9: RNA-directed DNA polymerase (Reverse transcriptase)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6626905235
+UniRef50_F9CZX7: DNA repair protein RecN	0.6613756614
+UniRef50_F9CZX7: DNA repair protein RecN|g__Bacteroides.s__Bacteroides_stercoris	0.6613756614
+UniRef50_U5Q6L5: RagB/SusD Domain-Containing Protein	0.6613756614
+UniRef50_U5Q6L5: RagB/SusD Domain-Containing Protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6613756614
+UniRef50_R5CWL9: Phosphoribulokinase	0.6561679790
+UniRef50_R5CWL9: Phosphoribulokinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6561679790
+UniRef50_Q5L883: Glutamate--tRNA ligase	0.6557377049
+UniRef50_Q5L883: Glutamate--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.6557377049
+UniRef50_B7FT50: Asparagine synthetase	0.6535947712
+UniRef50_B7FT50: Asparagine synthetase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6535947712
+UniRef50_P9WQK2	0.6497725796
+UniRef50_P9WQK2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6497725796
+UniRef50_D5BAW2: Sodium:solute symporter family protein	0.6472491909
+UniRef50_D5BAW2: Sodium:solute symporter family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6472491909
+UniRef50_R5JP66	0.6472491909
+UniRef50_R5JP66|g__Bacteroides.s__Bacteroides_stercoris	0.6472491909
+UniRef50_R5VIF5	0.6459948320
+UniRef50_R5VIF5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6459948320
+UniRef50_R6FM99	0.6459948320
+UniRef50_R6FM99|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6459948320
+UniRef50_R7ECP0	0.6459948320
+UniRef50_R7ECP0|g__Bacteroides.s__Bacteroides_stercoris	0.6459948320
+UniRef50_Q8A1T8: TPR-repeat-containing protein	0.6447453256
+UniRef50_Q8A1T8: TPR-repeat-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6447453256
+UniRef50_Q8A353: SusD homolog	0.6447453256
+UniRef50_Q8A353: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6447453256
+UniRef50_R6DG46: Arylsulfatase	0.6435006435
+UniRef50_R6DG46: Arylsulfatase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6435006435
+UniRef50_A5FIF9: Potassium-transporting ATPase A chain	0.6422607579
+UniRef50_A5FIF9: Potassium-transporting ATPase A chain|g__Bacteroides.s__Bacteroides_stercoris	0.6422607579
+UniRef50_Q8A2Z5: Alpha-1,3-galactosidase A	0.6422607579
+UniRef50_Q8A2Z5: Alpha-1,3-galactosidase A|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6422607579
+UniRef50_R7KKH7	0.6410256410
+UniRef50_R7KKH7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6410256410
+UniRef50_Q8A6V1: Galactose-binding-like protein	0.6397952655
+UniRef50_Q8A6V1: Galactose-binding-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6397952655
+UniRef50_R6L9N3: SusD family protein	0.6397952655
+UniRef50_R6L9N3: SusD family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6397952655
+UniRef50_R6LHG5: SusD family protein	0.6397952655
+UniRef50_R6LHG5: SusD family protein|g__Bacteroides.s__Bacteroides_stercoris	0.6397952655
+UniRef50_R7EQT9: Single-stranded-DNA-specific exonuclease RecJ	0.6373486297
+UniRef50_R7EQT9: Single-stranded-DNA-specific exonuclease RecJ|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6373486297
+UniRef50_Q73RR6: Formate--tetrahydrofolate ligase	0.6361323155
+UniRef50_Q73RR6: Formate--tetrahydrofolate ligase|g__Bacteroides.s__Bacteroides_stercoris	0.6361323155
+UniRef50_F0R157: Xenobiotic-transporting ATPase	0.6325110689
+UniRef50_F0R157: Xenobiotic-transporting ATPase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6325110689
+UniRef50_D6D7U9: SusD family	0.6313131313
+UniRef50_D6D7U9: SusD family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6313131313
+UniRef50_R6E831: TPR-repeat-containing protein	0.6301197227
+UniRef50_R6E831: TPR-repeat-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6301197227
+UniRef50_A6L3W6	0.6289308176
+UniRef50_A6L3W6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6289308176
+UniRef50_R7JAP3: Glutaminyl-tRNA synthetase	0.6289308176
+UniRef50_R7JAP3: Glutaminyl-tRNA synthetase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6289308176
+UniRef50_R6Y1L3: Outer membrane receptor proteins mostly Fe transport	0.6283380459
+UniRef50_R6Y1L3: Outer membrane receptor proteins mostly Fe transport|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6283380459
+UniRef50_B0NVE5	0.6265664160
+UniRef50_B0NVE5|g__Bacteroides.s__Bacteroides_stercoris	0.6265664160
+UniRef50_R5J4A1	0.6265664160
+UniRef50_R5J4A1|g__Bacteroides.s__Bacteroides_stercoris	0.6265664160
+UniRef50_R7KFK3	0.6265664160
+UniRef50_R7KFK3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6265664160
+UniRef50_R6JFJ8	0.6230529595
+UniRef50_R6JFJ8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6230529595
+UniRef50_Q8A5P2: SusC homolog	0.6224712107
+UniRef50_Q8A5P2: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6224712107
+UniRef50_B2GCF9: 1-deoxy-D-xylulose-5-phosphate synthase	0.6218905473
+UniRef50_B2GCF9: 1-deoxy-D-xylulose-5-phosphate synthase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6218905473
+UniRef50_I4BA63: H+transporting two-sector ATPase alpha/beta subunit central region	0.6218905473
+UniRef50_I4BA63: H+transporting two-sector ATPase alpha/beta subunit central region|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6218905473
+UniRef50_Q2S158: Aspartate--tRNA(Asp/Asn) ligase	0.6218905473
+UniRef50_Q2S158: Aspartate--tRNA(Asp/Asn) ligase|g__Bacteroides.s__Bacteroides_stercoris	0.6218905473
+UniRef50_R5N9P5	0.6207324643
+UniRef50_R5N9P5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6207324643
+UniRef50_R5UDW9	0.6207324643
+UniRef50_R5UDW9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6207324643
+UniRef50_U2JMV5: Beta-galactosidase family protein	0.6201550388
+UniRef50_U2JMV5: Beta-galactosidase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6201550388
+UniRef50_R7NX49: LysM-repeat domain-containing protein	0.6184291899
+UniRef50_R7NX49: LysM-repeat domain-containing protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6184291899
+UniRef50_E5WVI9	0.6172839506
+UniRef50_E5WVI9|g__Bacteroides.s__Bacteroides_stercoris	0.6172839506
+UniRef50_R5JC37	0.6172839506
+UniRef50_R5JC37|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6172839506
+UniRef50_R5UPV5: SusC/RagA family TonB-linked outer membrane protein	0.6150061501
+UniRef50_R5UPV5: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_stercoris	0.6150061501
+UniRef50_F0R821: RagB/SusD domain-containing protein	0.6105006105
+UniRef50_F0R821: RagB/SusD domain-containing protein|g__Bacteroides.s__Bacteroides_stercoris	0.6105006105
+UniRef50_Q8A1C5	0.6105006105
+UniRef50_Q8A1C5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6105006105
+UniRef50_R7H2N2: Chloride transporter ClC family	0.6093845216
+UniRef50_R7H2N2: Chloride transporter ClC family|g__Bacteroides.s__Bacteroides_stercoris	0.6093845216
+UniRef50_A6KZA8: Arginine--tRNA ligase	0.6082725061
+UniRef50_A6KZA8: Arginine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6082725061
+UniRef50_E4T141: SSU ribosomal protein S1P	0.6082725061
+UniRef50_E4T141: SSU ribosomal protein S1P|g__Bacteroides.s__Bacteroides_stercoris	0.6082725061
+UniRef50_F9D155: M24 family peptidase	0.6082725061
+UniRef50_F9D155: M24 family peptidase|g__Bacteroides.s__Bacteroides_stercoris	0.6082725061
+UniRef50_R6JQG9: TonB-dependent receptor plug domain protein	0.6077180188
+UniRef50_R6JQG9: TonB-dependent receptor plug domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6077180188
+UniRef50_Q8A796	0.6075334143
+UniRef50_Q8A796|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6075334143
+UniRef50_Q89ZE6	0.6060606061
+UniRef50_Q89ZE6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6060606061
+UniRef50_R5J064	0.6060606061
+UniRef50_R5J064|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6060606061
+UniRef50_R7A898: SusC/RagA family TonB-linked outer membrane protein	0.6055101423
+UniRef50_R7A898: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6055101423
+UniRef50_Q8A4S4: Alpha-rhamnosidase	0.6044122091
+UniRef50_Q8A4S4: Alpha-rhamnosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6044122091
+UniRef50_Q7MVU9: UPF0313 protein PG_0934	0.6038647343
+UniRef50_Q7MVU9: UPF0313 protein PG_0934|g__Bacteroides.s__Bacteroides_stercoris	0.6038647343
+UniRef50_R6XS51	0.6038647343
+UniRef50_R6XS51|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.6038647343
+UniRef50_R6B7K2	0.6027727547
+UniRef50_R6B7K2|g__Bacteroides.s__Bacteroides_stercoris	0.6027727547
+UniRef50_Q8A9K9: Isoleucine--tRNA ligase	0.5989817311
+UniRef50_Q8A9K9: Isoleucine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.5989817311
+UniRef50_W4PA70: Isoleucyl-tRNA synthetase	0.5989817311
+UniRef50_W4PA70: Isoleucyl-tRNA synthetase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5989817311
+UniRef50_A6L334: K+ uptake protein	0.5952380952
+UniRef50_A6L334: K+ uptake protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5952380952
+UniRef50_Q8A0X3: TonB	0.5952380952
+UniRef50_Q8A0X3: TonB|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5952380952
+UniRef50_R5BDA2	0.5952380952
+UniRef50_R5BDA2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5952380952
+UniRef50_R5M6Z7: Peptidase U32 family	0.5952380952
+UniRef50_R5M6Z7: Peptidase U32 family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5952380952
+UniRef50_D6CWL4: Beta-fructosidases (Levanase/invertase)	0.5941770648
+UniRef50_D6CWL4: Beta-fructosidases (Levanase/invertase)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5941770648
+UniRef50_R6VZJ1: Cna protein B-type domain protein	0.5910165485
+UniRef50_R6VZJ1: Cna protein B-type domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.5910165485
+UniRef50_R7E2E7	0.5910165485
+UniRef50_R7E2E7|g__Bacteroides.s__Bacteroides_stercoris	0.5910165485
+UniRef50_Q89ZX0: Alpha-1,3-galactosidase B	0.5889281508
+UniRef50_Q89ZX0: Alpha-1,3-galactosidase B|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5889281508
+UniRef50_D6CY89: SusD family	0.5858230814
+UniRef50_D6CY89: SusD family|g__Bacteroides.s__Bacteroides_stercoris	0.5858230814
+UniRef50_Q8A0D6: SusD homolog	0.5858230814
+UniRef50_Q8A0D6: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5858230814
+UniRef50_Q8AB57: UPF0313 protein BT_0254	0.5837711617
+UniRef50_Q8AB57: UPF0313 protein BT_0254|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5837711617
+UniRef50_R7EYT6: Penicillin-binding protein 2	0.5827505828
+UniRef50_R7EYT6: Penicillin-binding protein 2|g__Bacteroides.s__Bacteroides_stercoris	0.5827505828
+UniRef50_R5P5X8: SusC/RagA family TonB-linked outer membrane protein	0.5822416303
+UniRef50_R5P5X8: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_stercoris	0.5822416303
+UniRef50_Q8A3R1: SusD homolog	0.5797101449
+UniRef50_Q8A3R1: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5797101449
+UniRef50_R6B5M7: Precorrin-4 C(11)-methyltransferase	0.5787037037
+UniRef50_R6B5M7: Precorrin-4 C(11)-methyltransferase|g__Bacteroides.s__Bacteroides_stercoris	0.5787037037
+UniRef50_R6V6K6	0.5787037037
+UniRef50_R6V6K6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5787037037
+UniRef50_A6L0Y0: Glycoside hydrolase family 32, candidate levanase	0.5777007510
+UniRef50_A6L0Y0: Glycoside hydrolase family 32, candidate levanase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5777007510
+UniRef50_K4ISX9	0.5757052389
+UniRef50_K4ISX9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5757052389
+UniRef50_R5UAT7: Glycosyl hydrolase family 16	0.5727376861
+UniRef50_R5UAT7: Glycosyl hydrolase family 16|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5727376861
+UniRef50_Q59676: Methylmalonyl-CoA mutase small subunit	0.5717552887
+UniRef50_Q59676: Methylmalonyl-CoA mutase small subunit|g__Bacteroides.s__Bacteroides_stercoris	0.5717552887
+UniRef50_Q5LH44: 1-deoxy-D-xylulose-5-phosphate synthase	0.5688282139
+UniRef50_Q5LH44: 1-deoxy-D-xylulose-5-phosphate synthase|g__Bacteroides.s__Bacteroides_stercoris	0.5688282139
+UniRef50_I8V7H4	0.5676573772
+UniRef50_I8V7H4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2957704821
+UniRef50_I8V7H4|g__Bacteroides.s__Bacteroides_stercoris	0.2718868951
+UniRef50_E2NFM4: Proton-translocating NADH-quinone oxidoreductase, chain L	0.5668934240
+UniRef50_E2NFM4: Proton-translocating NADH-quinone oxidoreductase, chain L|g__Bacteroides.s__Bacteroides_stercoris	0.5668934240
+UniRef50_A0A015Q9A2	0.5659309564
+UniRef50_A0A015Q9A2|g__Bacteroides.s__Bacteroides_stercoris	0.5659309564
+UniRef50_R7EC20: Hsp90-like protein	0.5649717514
+UniRef50_R7EC20: Hsp90-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5649717514
+UniRef50_R5JSN7	0.5646527386
+UniRef50_R5JSN7|g__Bacteroides.s__Bacteroides_stercoris	0.5646527386
+UniRef50_Q8A087: SusD homolog	0.5640157924
+UniRef50_Q8A087: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5640157924
+UniRef50_R6KUS8: SusD homolog	0.5640157924
+UniRef50_R6KUS8: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5640157924
+UniRef50_R5UUD4	0.5630630631
+UniRef50_R5UUD4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5630630631
+UniRef50_R5VKI6	0.5630630631
+UniRef50_R5VKI6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5630630631
+UniRef50_Q8A1Y8: SusD homolog	0.5621135469
+UniRef50_Q8A1Y8: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5621135469
+UniRef50_A6L297	0.5602240896
+UniRef50_A6L297|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5602240896
+UniRef50_R5JRS8: Hsp90-like protein	0.5602240896
+UniRef50_R5JRS8: Hsp90-like protein|g__Bacteroides.s__Bacteroides_stercoris	0.5602240896
+UniRef50_G8THU4: Threonine--tRNA ligase	0.5583472920
+UniRef50_G8THU4: Threonine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.5583472920
+UniRef50_R6KN74	0.5574136009
+UniRef50_R6KN74|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5574136009
+UniRef50_D6D2F3: Predicted P-loop ATPase and inactivated derivatives	0.5537098560
+UniRef50_D6D2F3: Predicted P-loop ATPase and inactivated derivatives|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5537098560
+UniRef50_R6J801	0.5518763797
+UniRef50_R6J801|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5518763797
+UniRef50_U5Q855: DNA gyrase subunit B	0.5518763797
+UniRef50_U5Q855: DNA gyrase subunit B|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5518763797
+UniRef50_E1WUR9	0.5509641873
+UniRef50_E1WUR9|g__Bacteroides.s__Bacteroides_stercoris	0.5509641873
+UniRef50_R5JNS6	0.5500550055
+UniRef50_R5JNS6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5500550055
+UniRef50_R7KNC4	0.5500550055
+UniRef50_R7KNC4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5500550055
+UniRef50_R6LH43	0.5491488193
+UniRef50_R6LH43|g__Bacteroides.s__Bacteroides_stercoris	0.5491488193
+UniRef50_R7DJ50: DNA polymerase III alpha subunit	0.5473453749
+UniRef50_R7DJ50: DNA polymerase III alpha subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5473453749
+UniRef50_R5UNH2: Glycosyl hydrolase family 20 catalytic domain protein	0.5446623094
+UniRef50_R5UNH2: Glycosyl hydrolase family 20 catalytic domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5446623094
+UniRef50_R5PFV8: Sialic acid-specific 9-O-acetylesterase	0.5437737901
+UniRef50_R5PFV8: Sialic acid-specific 9-O-acetylesterase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5437737901
+UniRef50_R6M6L8: Oligopeptide transporter OPT family	0.5437737901
+UniRef50_R6M6L8: Oligopeptide transporter OPT family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5437737901
+UniRef50_Q7MW52: Fructose-1,6-bisphosphatase class 3	0.5420054201
+UniRef50_Q7MW52: Fructose-1,6-bisphosphatase class 3|g__Bacteroides.s__Bacteroides_stercoris	0.5420054201
+UniRef50_Q8A2J2	0.5393743258
+UniRef50_Q8A2J2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5393743258
+UniRef50_I9PR43: TonB family domain-containing protein	0.5376344086
+UniRef50_I9PR43: TonB family domain-containing protein|g__Bacteroides.s__Bacteroides_stercoris	0.5376344086
+UniRef50_Q8A2Z8: SusD homolog	0.5359056806
+UniRef50_Q8A2Z8: SusD homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5359056806
+UniRef50_R5JBX4	0.5359056806
+UniRef50_R5JBX4|g__Bacteroides.s__Bacteroides_stercoris	0.5359056806
+UniRef50_C9KZG4	0.5341880342
+UniRef50_C9KZG4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5341880342
+UniRef50_R6KML9	0.5299417064
+UniRef50_R6KML9|g__Bacteroides.s__Bacteroides_stercoris	0.5299417064
+UniRef50_R7DL47: Methionine--tRNA ligase	0.5291005291
+UniRef50_R7DL47: Methionine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5291005291
+UniRef50_R5U6Y1	0.5282620180
+UniRef50_R5U6Y1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5282620180
+UniRef50_R7EGT0	0.5274261603
+UniRef50_R7EGT0|g__Bacteroides.s__Bacteroides_stercoris	0.5274261603
+UniRef50_Q8A2Y8	0.5265929437
+UniRef50_Q8A2Y8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5265929437
+UniRef50_Q8A5J3	0.5265929437
+UniRef50_Q8A5J3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5265929437
+UniRef50_R5RES4: Beta-galactosidase	0.5265929437
+UniRef50_R5RES4: Beta-galactosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5265929437
+UniRef50_W4UTT1: Chaperone protein HtpG	0.5265929437
+UniRef50_W4UTT1: Chaperone protein HtpG|g__Bacteroides.s__Bacteroides_stercoris	0.5265929437
+UniRef50_R5MBV2: ComEC/Rec2-like protein	0.5249343832
+UniRef50_R5MBV2: ComEC/Rec2-like protein|g__Bacteroides.s__Bacteroides_stercoris	0.5249343832
+UniRef50_R6NQK2: Cyclic nucleotide-binding domain protein	0.5241090147
+UniRef50_R6NQK2: Cyclic nucleotide-binding domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.5241090147
+UniRef50_Q8A1G3: Alpha-amylase SusG	0.5232862376
+UniRef50_Q8A1G3: Alpha-amylase SusG|g__Bacteroides.s__Bacteroides_stercoris	0.5232862376
+UniRef50_R6VBD5	0.5228758170
+UniRef50_R6VBD5|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5228758170
+UniRef50_R5SVH9	0.5224660397
+UniRef50_R5SVH9|g__Bacteroides.s__Bacteroides_stercoris	0.5224660397
+UniRef50_F3ZTW8	0.5175983437
+UniRef50_F3ZTW8|g__Bacteroides.s__Bacteroides_stercoris	0.5175983437
+UniRef50_R5V0M9	0.5155968033
+UniRef50_R5V0M9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5155968033
+UniRef50_R7DUK0: Polyphosphate kinase	0.5151983514
+UniRef50_R7DUK0: Polyphosphate kinase|g__Bacteroides.s__Bacteroides_stercoris	0.5151983514
+UniRef50_R6V165: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)	0.5144032922
+UniRef50_R6V165: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5144032922
+UniRef50_W4P8H9: ATP-dependent DNA helicase RecG	0.5136106831
+UniRef50_W4P8H9: ATP-dependent DNA helicase RecG|g__Bacteroides.s__Bacteroides_stercoris	0.5136106831
+UniRef50_W4P379: Two-component system sensor histidine kinase/response	0.5108556833
+UniRef50_W4P379: Two-component system sensor histidine kinase/response|g__Bacteroides.s__Bacteroides_stercoris	0.5108556833
+UniRef50_E5X0X2: Translation elongation factor G	0.5081300813
+UniRef50_E5X0X2: Translation elongation factor G|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5081300813
+UniRef50_R6L5S5: VirE N-terminal domain protein	0.5058168943
+UniRef50_R6L5S5: VirE N-terminal domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.5058168943
+UniRef50_R7KDZ3: Transcriptional regulator	0.5042864347
+UniRef50_R7KDZ3: Transcriptional regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5042864347
+UniRef50_R7CYV8	0.5035246727
+UniRef50_R7CYV8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5035246727
+UniRef50_A6LD25: ATP-dependent zinc metalloprotease FtsH	0.5027652086
+UniRef50_A6LD25: ATP-dependent zinc metalloprotease FtsH|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5027652086
+UniRef50_R5RR30	0.5020080321
+UniRef50_R5RR30|g__Bacteroides.s__Bacteroides_stercoris	0.5020080321
+UniRef50_R5JK30: Competence protein ComEA helix-hairpin-helix repeat region	0.5012531328
+UniRef50_R5JK30: Competence protein ComEA helix-hairpin-helix repeat region|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5012531328
+UniRef50_Q8A6E8	0.5005005005
+UniRef50_Q8A6E8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5005005005
+UniRef50_R6SD13	0.5005005005
+UniRef50_R6SD13|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.5005005005
+UniRef50_A6LGN2: Glycoside hydrolase family 92	0.4990019960
+UniRef50_A6LGN2: Glycoside hydrolase family 92|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4990019960
+UniRef50_R6YNN2	0.4990019960
+UniRef50_R6YNN2|g__Bacteroides.s__Bacteroides_stercoris	0.4990019960
+UniRef50_G8ULE1: TonB-dependent receptor	0.4982561036
+UniRef50_G8ULE1: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4982561036
+UniRef50_R6DCY1: Alpha-galactosidase	0.4982561036
+UniRef50_R6DCY1: Alpha-galactosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4982561036
+UniRef50_R6W323	0.4982561036
+UniRef50_R6W323|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4982561036
+UniRef50_A6LH84: Ribonuclease R	0.4975124378
+UniRef50_A6LH84: Ribonuclease R|g__Bacteroides.s__Bacteroides_stercoris	0.4975124378
+UniRef50_R7E450	0.4975124378
+UniRef50_R7E450|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4975124378
+UniRef50_R5K992	0.4960317460
+UniRef50_R5K992|g__Bacteroides.s__Bacteroides_stercoris	0.4960317460
+UniRef50_R6EBG9	0.4960317460
+UniRef50_R6EBG9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4960317460
+UniRef50_F0R6L9	0.4930966469
+UniRef50_F0R6L9|g__Bacteroides.s__Bacteroides_stercoris	0.4930966469
+UniRef50_Q8A588	0.4930966469
+UniRef50_Q8A588|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4930966469
+UniRef50_D5BAK3	0.4923682915
+UniRef50_D5BAK3|g__Bacteroides.s__Bacteroides_stercoris	0.4923682915
+UniRef50_P15623: Glutamine synthetase	0.4901960784
+UniRef50_P15623: Glutamine synthetase|g__Bacteroides.s__Bacteroides_stercoris	0.4901960784
+UniRef50_R7CUQ8	0.4894762604
+UniRef50_R7CUQ8|g__Bacteroides.s__Bacteroides_stercoris	0.4894762604
+UniRef50_R5C130	0.4887585533
+UniRef50_R5C130|g__Bacteroides.s__Bacteroides_stercoris	0.4887585533
+UniRef50_R6TB39: Alpha-N-acetylglucosaminidase	0.4880429478
+UniRef50_R6TB39: Alpha-N-acetylglucosaminidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4880429478
+UniRef50_R5K4X9	0.4873294347
+UniRef50_R5K4X9|g__Bacteroides.s__Bacteroides_stercoris	0.4873294347
+UniRef50_Q8A294: Putative K(+)-stimulated pyrophosphate-energized sodium pump	0.4866180049
+UniRef50_Q8A294: Putative K(+)-stimulated pyrophosphate-energized sodium pump|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4866180049
+UniRef50_H1Y2M1: Alpha-1,2-mannosidase	0.4859086492
+UniRef50_H1Y2M1: Alpha-1,2-mannosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4859086492
+UniRef50_F9D614: Anaerobic ribonucleoside-triphosphate reductase	0.4852013586
+UniRef50_F9D614: Anaerobic ribonucleoside-triphosphate reductase|g__Bacteroides.s__Bacteroides_stercoris	0.4852013586
+UniRef50_Q89ZI2: O-GlcNAcase BT_4395	0.4844961240
+UniRef50_Q89ZI2: O-GlcNAcase BT_4395|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4844961240
+UniRef50_R6LDE7	0.4830917874
+UniRef50_R6LDE7|g__Bacteroides.s__Bacteroides_stercoris	0.4830917874
+UniRef50_W4USI9: Na(+)/H(+) antiporter	0.4816955684
+UniRef50_W4USI9: Na(+)/H(+) antiporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4816955684
+UniRef50_Q8A0W2	0.4810004810
+UniRef50_Q8A0W2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4810004810
+UniRef50_R6T0L9: Formate acetyltransferase	0.4810004810
+UniRef50_R6T0L9: Formate acetyltransferase|g__Bacteroides.s__Bacteroides_stercoris	0.4810004810
+UniRef50_R5JTT4	0.4775549188
+UniRef50_R5JTT4|g__Bacteroides.s__Bacteroides_stercoris	0.4775549188
+UniRef50_R6L7R7: Phosphate transporter family protein	0.4775549188
+UniRef50_R6L7R7: Phosphate transporter family protein|g__Bacteroides.s__Bacteroides_stercoris	0.4775549188
+UniRef50_R7IN27: Aconitate hydratase	0.4775549188
+UniRef50_R7IN27: Aconitate hydratase|g__Bacteroides.s__Bacteroides_stercoris	0.4775549188
+UniRef50_R6KRM0	0.4758505829
+UniRef50_R6KRM0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4758505829
+UniRef50_R5S715: Alpha-1 2-mannosidase family protein	0.4734848485
+UniRef50_R5S715: Alpha-1 2-mannosidase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4734848485
+UniRef50_R7ESL0	0.4675081814
+UniRef50_R7ESL0|g__Bacteroides.s__Bacteroides_stercoris	0.4675081814
+UniRef50_W4PK35: NADP-dependent malic enzyme	0.4668534080
+UniRef50_W4PK35: NADP-dependent malic enzyme|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4668534080
+UniRef50_R6LNA6: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein	0.4645760743
+UniRef50_R6LNA6: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.4645760743
+UniRef50_R7JQ95	0.4642525534
+UniRef50_R7JQ95|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4642525534
+UniRef50_R6ADK9: Peptidase S54 family	0.4616805171
+UniRef50_R6ADK9: Peptidase S54 family|g__Bacteroides.s__Bacteroides_stercoris	0.4616805171
+UniRef50_D6D3S8: Penicillin-binding protein 1C	0.4610419548
+UniRef50_D6D3S8: Penicillin-binding protein 1C|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4610419548
+UniRef50_E6SRS8: Beta-N-acetylhexosaminidase	0.4597701149
+UniRef50_E6SRS8: Beta-N-acetylhexosaminidase|g__Bacteroides.s__Bacteroides_stercoris	0.4597701149
+UniRef50_R6UY01	0.4591368228
+UniRef50_R6UY01|g__Bacteroides.s__Bacteroides_stercoris	0.4591368228
+UniRef50_R6CFI1	0.4585052728
+UniRef50_R6CFI1|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4585052728
+UniRef50_C6XZB6: Heparin and heparin-sulfate lyase	0.4566210046
+UniRef50_C6XZB6: Heparin and heparin-sulfate lyase|g__Bacteroides.s__Bacteroides_stercoris	0.4566210046
+UniRef50_R6E1F6: PAS domain S-box protein	0.4528985507
+UniRef50_R6E1F6: PAS domain S-box protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4528985507
+UniRef50_R6PKV8: ATP-dependent DNA helicase PcrA	0.4510599910
+UniRef50_R6PKV8: ATP-dependent DNA helicase PcrA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4510599910
+UniRef50_R7EJ31	0.4492362983
+UniRef50_R7EJ31|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4492362983
+UniRef50_Q89YX8: Chaperone protein dnaK	0.4486316734
+UniRef50_Q89YX8: Chaperone protein dnaK|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4486316734
+UniRef50_R5CR06: TonB-dependent receptor plug domain protein	0.4480286738
+UniRef50_R5CR06: TonB-dependent receptor plug domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.4480286738
+UniRef50_A6L0H6	0.4438526409
+UniRef50_A6L0H6|g__Bacteroides.s__Bacteroides_stercoris	0.4438526409
+UniRef50_R6AYT4	0.4420866490
+UniRef50_R6AYT4|g__Bacteroides.s__Bacteroides_stercoris	0.4420866490
+UniRef50_R5JJP2	0.4411317895
+UniRef50_R5JJP2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4411317895
+UniRef50_R6E1E0	0.4374453193
+UniRef50_R6E1E0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4374453193
+UniRef50_R6SCN4: Primosomal protein N	0.4334633723
+UniRef50_R6SCN4: Primosomal protein N|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4334633723
+UniRef50_Q8AA39: Phenylalanine--tRNA ligase beta subunit	0.4323389537
+UniRef50_Q8AA39: Phenylalanine--tRNA ligase beta subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4323389537
+UniRef50_A6L531: Lon protease	0.4306632214
+UniRef50_A6L531: Lon protease|g__Bacteroides.s__Bacteroides_stercoris	0.4306632214
+UniRef50_R5V1Q8	0.4306632214
+UniRef50_R5V1Q8|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4306632214
+UniRef50_R6A6J8	0.4306632214
+UniRef50_R6A6J8|g__Bacteroides.s__Bacteroides_stercoris	0.4306632214
+UniRef50_R5JCI3	0.4295532646
+UniRef50_R5JCI3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4295532646
+UniRef50_Q7MXK3: Pyridine nucleotide-disulphide oxidoreductase family protein	0.4290004290
+UniRef50_Q7MXK3: Pyridine nucleotide-disulphide oxidoreductase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4290004290
+UniRef50_Q8A5J6: Protein prenyltransferase	0.4290004290
+UniRef50_Q8A5J6: Protein prenyltransferase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4290004290
+UniRef50_R6LNL6: Heparinase II/III-like protein	0.4246284501
+UniRef50_R6LNL6: Heparinase II/III-like protein|g__Bacteroides.s__Bacteroides_stercoris	0.4246284501
+UniRef50_W0EY48: Cell division protein FtsK	0.4224757076
+UniRef50_W0EY48: Cell division protein FtsK|g__Bacteroides.s__Bacteroides_stercoris	0.4224757076
+UniRef50_W4PWJ1: ATP-dependent Clp protease ATP-binding subunit ClpA	0.4208754209
+UniRef50_W4PWJ1: ATP-dependent Clp protease ATP-binding subunit ClpA|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4208754209
+UniRef50_F3ZRV7: Polysaccharide deacetylase	0.4203446826
+UniRef50_F3ZRV7: Polysaccharide deacetylase|g__Bacteroides.s__Bacteroides_stercoris	0.4203446826
+UniRef50_R6MGF8: Glycosyl hydrolase family 88	0.4203446826
+UniRef50_R6MGF8: Glycosyl hydrolase family 88|g__Bacteroides.s__Bacteroides_stercoris	0.4203446826
+UniRef50_A7V674	0.4192872117
+UniRef50_A7V674|g__Bacteroides.s__Bacteroides_stercoris	0.4192872117
+UniRef50_R6DAL5	0.4187604690
+UniRef50_R6DAL5|g__Bacteroides.s__Bacteroides_stercoris	0.4187604690
+UniRef50_R6V688	0.4171881519
+UniRef50_R6V688|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4171881519
+UniRef50_Q8A2M3	0.4166666667
+UniRef50_Q8A2M3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4166666667
+UniRef50_R7DK62	0.4161464836
+UniRef50_R7DK62|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4161464836
+UniRef50_E6SRR3: Cobaltochelatase CobN subunit	0.4140786749
+UniRef50_E6SRR3: Cobaltochelatase CobN subunit|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4140786749
+UniRef50_A6KYY0	0.4125412541
+UniRef50_A6KYY0|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4125412541
+UniRef50_R6V2H3	0.4125412541
+UniRef50_R6V2H3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4125412541
+UniRef50_R6DNC6	0.4120313144
+UniRef50_R6DNC6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4120313144
+UniRef50_R6V2A4	0.4100041000
+UniRef50_R6V2A4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4100041000
+UniRef50_R6USZ4	0.4070004070
+UniRef50_R6USZ4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4070004070
+UniRef50_R5IDT6: Heparinase II/III-like protein	0.4045307443
+UniRef50_R5IDT6: Heparinase II/III-like protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4045307443
+UniRef50_A6L738	0.4016064257
+UniRef50_A6L738|g__Bacteroides.s__Bacteroides_stercoris	0.4016064257
+UniRef50_R5TVB0: Outer membrane protein assembly complex YaeT protein	0.4016064257
+UniRef50_R5TVB0: Outer membrane protein assembly complex YaeT protein|g__Bacteroides.s__Bacteroides_stercoris	0.4016064257
+UniRef50_D6D1X9: TonB-dependent Receptor Plug Domain	0.4011231448
+UniRef50_D6D1X9: TonB-dependent Receptor Plug Domain|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.4011231448
+UniRef50_R6ZUC7	0.3996802558
+UniRef50_R6ZUC7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3996802558
+UniRef50_R6FBS9: Valine--tRNA ligase	0.3944773176
+UniRef50_R6FBS9: Valine--tRNA ligase|g__Bacteroides.s__Bacteroides_stercoris	0.3944773176
+UniRef50_Q8A3A6	0.3940110323
+UniRef50_Q8A3A6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3940110323
+UniRef50_F2KVD6: TonB-linked outer membrane protein, SusC/RagA family	0.3926187672
+UniRef50_F2KVD6: TonB-linked outer membrane protein, SusC/RagA family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3926187672
+UniRef50_R7KYE3: PAS domain S-box protein	0.3903200625
+UniRef50_R7KYE3: PAS domain S-box protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3903200625
+UniRef50_A6LGN1: Glycoside hydrolase family 78	0.3898635478
+UniRef50_A6LGN1: Glycoside hydrolase family 78|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3898635478
+UniRef50_A0A016A5N0: Calcineurin-like phosphoesterase family protein	0.3894080997
+UniRef50_A0A016A5N0: Calcineurin-like phosphoesterase family protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3894080997
+UniRef50_R6IPY9	0.3853564547
+UniRef50_R6IPY9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3853564547
+UniRef50_I8UZ19	0.3840245776
+UniRef50_I8UZ19|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3840245776
+UniRef50_R6L8R6	0.3827018752
+UniRef50_R6L8R6|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3827018752
+UniRef50_F0R2J5: Lipolytic protein G-D-S-L family	0.3809523810
+UniRef50_F0R2J5: Lipolytic protein G-D-S-L family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3809523810
+UniRef50_R7KFQ3	0.3783579266
+UniRef50_R7KFQ3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3783579266
+UniRef50_R6ABH0: Leucine Rich Repeat protein	0.3779289494
+UniRef50_R6ABH0: Leucine Rich Repeat protein|g__Bacteroides.s__Bacteroides_stercoris	0.3779289494
+UniRef50_UPI000468D7B3: membrane protein	0.3775009438
+UniRef50_UPI000468D7B3: membrane protein|g__Bacteroides.s__Bacteroides_stercoris	0.3775009438
+UniRef50_B0NVC6	0.3757985720
+UniRef50_B0NVC6|g__Bacteroides.s__Bacteroides_stercoris	0.3757985720
+UniRef50_R6JPJ7: Peptidase M16 inactive domain protein	0.3745318352
+UniRef50_R6JPJ7: Peptidase M16 inactive domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.3745318352
+UniRef50_R5DGH3	0.3724394786
+UniRef50_R5DGH3|g__Bacteroides.s__Bacteroides_stercoris	0.3724394786
+UniRef50_C6W4A8: DNA polymerase I	0.3703703704
+UniRef50_C6W4A8: DNA polymerase I|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3703703704
+UniRef50_D6CWG8: Outer membrane receptor for ferrienterochelin and colicins	0.3687315634
+UniRef50_D6CWG8: Outer membrane receptor for ferrienterochelin and colicins|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3687315634
+UniRef50_R6JEN9: Outer membrane protein	0.3679175865
+UniRef50_R6JEN9: Outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3679175865
+UniRef50_H8KX53: TonB-linked outer membrane protein, SusC/RagA family	0.3663003663
+UniRef50_H8KX53: TonB-linked outer membrane protein, SusC/RagA family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3663003663
+UniRef50_R5W6Y4	0.3654970760
+UniRef50_R5W6Y4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3654970760
+UniRef50_D9RX34: DNA primase small subunit	0.3635041803
+UniRef50_D9RX34: DNA primase small subunit|g__Bacteroides.s__Bacteroides_stercoris	0.3635041803
+UniRef50_R7DZW3: Chondroitin sulfate ABC lyase	0.3635041803
+UniRef50_R7DZW3: Chondroitin sulfate ABC lyase|g__Bacteroides.s__Bacteroides_stercoris	0.3635041803
+UniRef50_R7DSH7: Fibronectin type III domain protein	0.3619254434
+UniRef50_R7DSH7: Fibronectin type III domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3619254434
+UniRef50_E6SRT3: Alpha-1,2-mannosidase	0.3599712023
+UniRef50_E6SRT3: Alpha-1,2-mannosidase|g__Bacteroides.s__Bacteroides_stercoris	0.3599712023
+UniRef50_F3PEE8: Fibronectin type III domain protein	0.3595828839
+UniRef50_F3PEE8: Fibronectin type III domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.3595828839
+UniRef50_R7NUS0: Glycosyl hydrolase family 88	0.3580379520
+UniRef50_R7NUS0: Glycosyl hydrolase family 88|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3580379520
+UniRef50_R6DLA2	0.3572704537
+UniRef50_R6DLA2|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3572704537
+UniRef50_Q8A069: Beta-galactosidase I	0.3557452864
+UniRef50_Q8A069: Beta-galactosidase I|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3557452864
+UniRef50_A0A015R3S0: TonB-dependent Receptor Plug domain protein (Fragment)	0.3527336861
+UniRef50_A0A015R3S0: TonB-dependent Receptor Plug domain protein (Fragment)|g__Bacteroides.s__Bacteroides_stercoris	0.3527336861
+UniRef50_E5CDR5: SusC/RagA family TonB-linked outer membrane protein	0.3483106931
+UniRef50_E5CDR5: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3483106931
+UniRef50_W4UYD9: RND multidrug efflux transporter	0.3468609088
+UniRef50_W4UYD9: RND multidrug efflux transporter|g__Bacteroides.s__Bacteroides_stercoris	0.3468609088
+UniRef50_Q89YN9	0.3465003465
+UniRef50_Q89YN9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3465003465
+UniRef50_R5TUC7: TonB-linked outer membrane protein SusC/RagA family	0.3415300546
+UniRef50_R5TUC7: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3415300546
+UniRef50_C7M5I0: TonB-dependent receptor	0.3411804845
+UniRef50_C7M5I0: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_stercoris	0.3411804845
+UniRef50_J9CMJ3: Chondroitinase (Chondroitin lyase)	0.3408316292
+UniRef50_J9CMJ3: Chondroitinase (Chondroitin lyase)|g__Bacteroides.s__Bacteroides_stercoris	0.3408316292
+UniRef50_R6JIE4	0.3408316292
+UniRef50_R6JIE4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3408316292
+UniRef50_F4C4Q6: TonB-dependent receptor	0.3397893306
+UniRef50_F4C4Q6: TonB-dependent receptor|g__Bacteroides.s__Bacteroides_stercoris	0.3397893306
+UniRef50_R7KG39	0.3394433130
+UniRef50_R7KG39|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3394433130
+UniRef50_R6XL42: SusC homolog	0.3387533875
+UniRef50_R6XL42: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3387533875
+UniRef50_R5JMI4: Hydrophobe/amphiphile efflux-1 family RND transporter	0.3384094755
+UniRef50_R5JMI4: Hydrophobe/amphiphile efflux-1 family RND transporter|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3384094755
+UniRef50_R6ZCC3	0.3367003367
+UniRef50_R6ZCC3|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3367003367
+UniRef50_Q8A693	0.3353454058
+UniRef50_Q8A693|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3353454058
+UniRef50_A0A015MLD6: MMPL family protein (Fragment)	0.3343363424
+UniRef50_A0A015MLD6: MMPL family protein (Fragment)|g__Bacteroides.s__Bacteroides_stercoris	0.3343363424
+UniRef50_F9Z581: Acriflavin resistance protein	0.3343363424
+UniRef50_F9Z581: Acriflavin resistance protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3343363424
+UniRef50_R6ZZ63	0.3340013360
+UniRef50_R6ZZ63|g__Bacteroides.s__Bacteroides_stercoris	0.3340013360
+UniRef50_Q8A2V4	0.3336670003
+UniRef50_Q8A2V4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3336670003
+UniRef50_R6XC24: Outer membrane protein	0.3333333333
+UniRef50_R6XC24: Outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3333333333
+UniRef50_Q8A053: SusC homolog	0.3330003330
+UniRef50_Q8A053: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3330003330
+UniRef50_R6DKH0: SusC/RagA family TonB-linked outer membrane protein	0.3330003330
+UniRef50_R6DKH0: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3330003330
+UniRef50_U2IIX4	0.3293807642
+UniRef50_U2IIX4|g__Bacteroides.s__Bacteroides_stercoris	0.3293807642
+UniRef50_E1WVX2	0.3280839895
+UniRef50_E1WVX2|g__Bacteroides.s__Bacteroides_stercoris	0.3280839895
+UniRef50_R6D531	0.3229974160
+UniRef50_R6D531|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3229974160
+UniRef50_Q650E1	0.3220611916
+UniRef50_Q650E1|g__Bacteroides.s__Bacteroides_stercoris	0.3220611916
+UniRef50_Q8ABT1: SusC homolog	0.3211303789
+UniRef50_Q8ABT1: SusC homolog|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3211303789
+UniRef50_R5JGD8: SusC/RagA family TonB-linked outer membrane protein	0.3208213025
+UniRef50_R5JGD8: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_stercoris	0.3208213025
+UniRef50_R6UZ57: Outer membrane protein	0.3208213025
+UniRef50_R6UZ57: Outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3208213025
+UniRef50_Q8A8I2: OmpA-related protein	0.3202049312
+UniRef50_Q8A8I2: OmpA-related protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3202049312
+UniRef50_R5JDF9	0.3192848020
+UniRef50_R5JDF9|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3192848020
+UniRef50_A0LYR8: Protein translocase subunit SecA	0.3177629488
+UniRef50_A0LYR8: Protein translocase subunit SecA|g__Bacteroides.s__Bacteroides_stercoris	0.3177629488
+UniRef50_Q8A794: SusC homolog	0.3159557662
+UniRef50_Q8A794: SusC homolog|g__Bacteroides.s__Bacteroides_stercoris	0.3159557662
+UniRef50_W6P1M0: Glycoside hydrolase family 2, sugar binding	0.3156565657
+UniRef50_W6P1M0: Glycoside hydrolase family 2, sugar binding|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3156565657
+UniRef50_Q64XY7: DNA helicase	0.3100775194
+UniRef50_Q64XY7: DNA helicase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3100775194
+UniRef50_R6FCT7: TonB-dependent receptor plug domain protein	0.3095017023
+UniRef50_R6FCT7: TonB-dependent receptor plug domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.3095017023
+UniRef50_R5V0V4: SusC/RagA family TonB-linked outer membrane protein	0.3089280198
+UniRef50_R5V0V4: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3089280198
+UniRef50_B0NLM6: Glycosyl hydrolase family 20, catalytic domain protein	0.3024803388
+UniRef50_B0NLM6: Glycosyl hydrolase family 20, catalytic domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.3024803388
+UniRef50_F2KX57: Helicase C-terminal domain protein	0.3008423586
+UniRef50_F2KX57: Helicase C-terminal domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.3008423586
+UniRef50_Q7MUD3: Isoleucine--tRNA ligase	0.2994908655
+UniRef50_Q7MUD3: Isoleucine--tRNA ligase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2994908655
+UniRef50_R6KN29	0.2994908655
+UniRef50_R6KN29|g__Bacteroides.s__Bacteroides_stercoris	0.2994908655
+UniRef50_B0NNP8	0.2992220227
+UniRef50_B0NNP8|g__Bacteroides.s__Bacteroides_stercoris	0.2992220227
+UniRef50_R6L5I6: TonB-linked outer membrane protein SusC/RagA family	0.2931691586
+UniRef50_R6L5I6: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides.s__Bacteroides_stercoris	0.2931691586
+UniRef50_Q8A5P7: Beta-galactosidase	0.2911208151
+UniRef50_Q8A5P7: Beta-galactosidase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2911208151
+UniRef50_Q89YI7	0.2841716397
+UniRef50_Q89YI7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2841716397
+UniRef50_A0A015PUG3	0.2610284521
+UniRef50_A0A015PUG3|g__Bacteroides.s__Bacteroides_stercoris	0.2610284521
+UniRef50_Q8A8I4: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)	0.2590002590
+UniRef50_Q8A8I4: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2590002590
+UniRef50_Q8A2V3: Cell well associated RhsD protein	0.2587991718
+UniRef50_Q8A2V3: Cell well associated RhsD protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2587991718
+UniRef50_R5P153: Response regulator receiver domain protein	0.2587991718
+UniRef50_R5P153: Response regulator receiver domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2587991718
+UniRef50_R7KML3: Two-component system sensor histidine kinase/response regulator	0.2585983967
+UniRef50_R7KML3: Two-component system sensor histidine kinase/response regulator|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2585983967
+UniRef50_B0NL59: Putative serine--tRNA ligase domain protein	0.2581977795
+UniRef50_B0NL59: Putative serine--tRNA ligase domain protein|g__Bacteroides.s__Bacteroides_stercoris	0.2581977795
+UniRef50_R7KUE4	0.2575991757
+UniRef50_R7KUE4|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2575991757
+UniRef50_Q8A241: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)	0.2572016461
+UniRef50_Q8A241: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2572016461
+UniRef50_R6ACZ9: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein	0.2556237219
+UniRef50_R6ACZ9: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2556237219
+UniRef50_R5JH28	0.2531004809
+UniRef50_R5JH28|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2531004809
+UniRef50_R6W605: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)	0.2495009980
+UniRef50_R6W605: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2495009980
+UniRef50_D6D1E3: Signal transduction histidine kinase	0.2411963338
+UniRef50_D6D1E3: Signal transduction histidine kinase|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2411963338
+UniRef50_R6VIN5: DNA-directed RNA polymerase	0.2411963338
+UniRef50_R6VIN5: DNA-directed RNA polymerase|g__Bacteroides.s__Bacteroides_stercoris	0.2411963338
+UniRef50_R6JLD1: Two-component system sensor histidine kinase/response regulator hybrid (One component system)	0.2342468962
+UniRef50_R6JLD1: Two-component system sensor histidine kinase/response regulator hybrid (One component system)|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2342468962
+UniRef50_R6L7N8	0.2302025783
+UniRef50_R6L7N8|g__Bacteroides.s__Bacteroides_stercoris	0.2302025783
+UniRef50_G8UNW7: ABC transporter, ATP-binding protein	0.2192982456
+UniRef50_G8UNW7: ABC transporter, ATP-binding protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2192982456
+UniRef50_R6D9I7	0.2142245073
+UniRef50_R6D9I7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.2142245073
+UniRef50_A0A016I611: Prophage LambdaSa1, N-acetylmuramoyl-L-alanine amidase, family 4	0.1902587519
+UniRef50_A0A016I611: Prophage LambdaSa1, N-acetylmuramoyl-L-alanine amidase, family 4|g__Bacteroides.s__Bacteroides_stercoris	0.1902587519
+UniRef50_R7KMV8: Outer membrane protein	0.1818512457
+UniRef50_R7KMV8: Outer membrane protein|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.1818512457
+UniRef50_Q89ZD7	0.1562011871
+UniRef50_Q89ZD7|g__Bacteroides.s__Bacteroides_thetaiotaomicron	0.1562011871

--- a/humann/tests/data/tooltest-genefamilies_genus_level/genus_level_genefamilies.tsv
+++ b/humann/tests/data/tooltest-genefamilies_genus_level/genus_level_genefamilies.tsv
@@ -1,0 +1,2824 @@
+# Gene Family	demo_Abundance-RPKs
+UNMAPPED	100.0000000000
+UniRef50_R5IH84	37.0370370370
+UniRef50_R5IH84|g__Bacteroides	37.037037037
+UniRef50_B0NQY6	25.6410256410
+UniRef50_B0NQY6|g__Bacteroides	25.641025641
+UniRef50_F3PHD0	25.6410256410
+UniRef50_F3PHD0|g__Bacteroides	25.641025641
+UniRef50_B0NP96	23.8095238095
+UniRef50_B0NP96|g__Bacteroides	23.8095238095
+UniRef50_B0NTS9	21.2765957447
+UniRef50_B0NTS9|g__Bacteroides	21.2765957447
+UniRef50_R6FNM5	16.1290322581
+UniRef50_R6FNM5|g__Bacteroides	16.1290322581
+UniRef50_A6L108	15.6250000000
+UniRef50_A6L108|g__Bacteroides	15.625
+UniRef50_B0NWG2	13.3333333333
+UniRef50_B0NWG2|g__Bacteroides	13.3333333333
+UniRef50_R6XJU3: Sec-independent protein translocase protein TatA	12.3456790123
+UniRef50_R6XJU3: Sec-independent protein translocase protein TatA|g__Bacteroides	12.3456790123
+UniRef50_R5JQA6	11.9047619048
+UniRef50_R5JQA6|g__Bacteroides	11.9047619048
+UniRef50_Q8A9G3	10.7526881720
+UniRef50_Q8A9G3|g__Bacteroides	10.752688172
+UniRef50_B6YQ01: 50S ribosomal protein L11	10.2040816327
+UniRef50_B6YQ01: 50S ribosomal protein L11|g__Bacteroides	10.204081632600001
+UniRef50_R5FJB9: Conjugative transposon TraN protein	9.9476081017
+UniRef50_R5FJB9: Conjugative transposon TraN protein|g__Bacteroides	9.9476081017
+UniRef50_R5BGD6	9.8039215686
+UniRef50_R5BGD6|g__Bacteroides	9.8039215686
+UniRef50_R7JA39: PF13711 domain protein	9.8039215686
+UniRef50_R7JA39: PF13711 domain protein|g__Bacteroides	9.8039215686
+UniRef50_E1WUR5	9.5238095238
+UniRef50_E1WUR5|g__Bacteroides	9.5238095238
+UniRef50_B6YQ88: 30S ribosomal protein S7	9.1743119266
+UniRef50_B6YQ88: 30S ribosomal protein S7|g__Bacteroides	9.1743119266
+UniRef50_Q2S3Q3: 50S ribosomal protein L24	9.0871771906
+UniRef50_Q2S3Q3: 50S ribosomal protein L24|g__Bacteroides	9.0871771906
+UniRef50_C1A930: 50S ribosomal protein L27	8.3333333333
+UniRef50_C1A930: 50S ribosomal protein L27|g__Bacteroides	8.3333333333
+UniRef50_B0NV53	8.1967213115
+UniRef50_B0NV53|g__Bacteroides	8.1967213115
+UniRef50_R6AHC9	8.1967213115
+UniRef50_R6AHC9|g__Bacteroides	8.1967213115
+UniRef50_R5F6Z7	7.7519379845
+UniRef50_R5F6Z7|g__Bacteroides	7.7519379845
+UniRef50_R6M7F9	7.7519379845
+UniRef50_R6M7F9|g__Bacteroides	7.7519379845
+UniRef50_A6KYI0: 50S ribosomal protein L6	7.1428571429
+UniRef50_A6KYI0: 50S ribosomal protein L6|g__Bacteroides	7.1428571429
+UniRef50_R5CEU4	7.0921985816
+UniRef50_R5CEU4|g__Bacteroides	7.0921985816
+UniRef50_R5I0U3	7.0921985816
+UniRef50_R5I0U3|g__Bacteroides	7.0921985816
+UniRef50_Q8A3G7	6.8027210884
+UniRef50_Q8A3G7|g__Bacteroides	6.8027210884
+UniRef50_Q5L9B7: 50S ribosomal protein L9	6.6666666667
+UniRef50_Q5L9B7: 50S ribosomal protein L9|g__Bacteroides	6.6666666667
+UniRef50_R5V945	6.6666666667
+UniRef50_R5V945|g__Bacteroides	6.6666666667
+UniRef50_I0Q078	6.5789473684
+UniRef50_I0Q078|unclassified	6.5789473684
+UniRef50_A0A015YH91	6.4516129032
+UniRef50_A0A015YH91|g__Bacteroides	6.4516129032
+UniRef50_D1KAI8	6.4102564103
+UniRef50_D1KAI8|g__Bacteroides	6.4102564103
+UniRef50_A6KY76	6.2893081761
+UniRef50_A6KY76|g__Bacteroides	6.2893081761
+UniRef50_R6L4G2	6.2893081761
+UniRef50_R6L4G2|g__Bacteroides	6.2893081761
+UniRef50_W0ESG7: DNA-binding protein	6.2893081761
+UniRef50_W0ESG7: DNA-binding protein|g__Bacteroides	6.2893081761
+UniRef50_A0A016LIR2	6.2500000000
+UniRef50_A0A016LIR2|g__Bacteroides	6.25
+UniRef50_R7IYZ7	6.1728395062
+UniRef50_R7IYZ7|g__Bacteroides	6.1728395062
+UniRef50_F5XD83: Conjugative transposon protein TraK	5.8297152408
+UniRef50_F5XD83: Conjugative transposon protein TraK|g__Bacteroides	5.829715240900001
+UniRef50_R6KK61	5.7142857143
+UniRef50_R6KK61|g__Bacteroides	5.7142857143
+UniRef50_P0A864: Thiol peroxidase	5.6497175141
+UniRef50_P0A864: Thiol peroxidase|g__Bacteroides	5.6497175141
+UniRef50_R5JE58	5.6497175141
+UniRef50_R5JE58|g__Bacteroides	5.6497175141
+UniRef50_F9D2T3: Ribosome-binding factor A	5.4644808743
+UniRef50_F9D2T3: Ribosome-binding factor A|g__Bacteroides	5.4644808743
+UniRef50_Q8A7R3	5.3763440860
+UniRef50_Q8A7R3|g__Bacteroides	5.376344086
+UniRef50_R6EAJ7	5.3763440860
+UniRef50_R6EAJ7|g__Bacteroides	5.376344086
+UniRef50_R7PE88: Methylglyoxal synthase	5.2940064284
+UniRef50_R7PE88: Methylglyoxal synthase|g__Bacteroides	5.2940064284999995
+UniRef50_I3YN79	5.2910052910
+UniRef50_I3YN79|g__Bacteroides	5.291005291
+UniRef50_Q5LIQ7: Shikimate kinase	5.2910052910
+UniRef50_Q5LIQ7: Shikimate kinase|g__Bacteroides	5.291005291
+UniRef50_R5C4D7	5.2083333333
+UniRef50_R5C4D7|g__Bacteroides	5.2083333333
+UniRef50_B0NU42	5.1282051282
+UniRef50_B0NU42|g__Bacteroides	5.1282051282
+UniRef50_E1WVZ0	5.1282051282
+UniRef50_E1WVZ0|g__Bacteroides	5.1282051282
+UniRef50_R5JPY8: RNA polymerase sigma factor	5.1282051282
+UniRef50_R5JPY8: RNA polymerase sigma factor|g__Bacteroides	5.1282051282
+UniRef50_R6KNV0: Thioredoxin	5.1282051282
+UniRef50_R6KNV0: Thioredoxin|g__Bacteroides	5.1282051282
+UniRef50_Q8A0V3: Pyridoxine 5'-phosphate synthase	5.1020408163
+UniRef50_Q8A0V3: Pyridoxine 5'-phosphate synthase|g__Bacteroides	5.1020408163
+UniRef50_Q89ZC3: 7-carboxy-7-deazaguanine synthase	5.0125313283
+UniRef50_Q89ZC3: 7-carboxy-7-deazaguanine synthase|g__Bacteroides	5.0125313283
+UniRef50_A6KYF8	4.9751243781
+UniRef50_A6KYF8|g__Bacteroides	4.9751243781
+UniRef50_I3YIX3	4.9751243781
+UniRef50_I3YIX3|g__Bacteroides	4.9751243781
+UniRef50_Q6ADC9: 50S ribosomal protein L20	4.9751243781
+UniRef50_Q6ADC9: 50S ribosomal protein L20|g__Bacteroides	4.9751243781
+UniRef50_R7J836	4.9504950495
+UniRef50_R7J836|g__Bacteroides	4.9504950495
+UniRef50_Q7MT66: 30S ribosomal protein S16	4.9382716049
+UniRef50_Q7MT66: 30S ribosomal protein S16|g__Bacteroides	4.9382716049
+UniRef50_E1WVZ2	4.9019607843
+UniRef50_E1WVZ2|g__Bacteroides	4.9019607843
+UniRef50_Q8A4V8: 50S ribosomal protein L19	4.9019607843
+UniRef50_Q8A4V8: 50S ribosomal protein L19|g__Bacteroides	4.9019607843
+UniRef50_B0NW87	4.7619047619
+UniRef50_B0NW87|g__Bacteroides	4.7619047619
+UniRef50_Q64WL5: Conserved protein found in conjugate transposon	4.7393364929
+UniRef50_Q64WL5: Conserved protein found in conjugate transposon|g__Bacteroides	4.7393364929
+UniRef50_A6L9Z9	4.6948356808
+UniRef50_A6L9Z9|g__Bacteroides	4.6948356808
+UniRef50_G8UNP4	4.6620046620
+UniRef50_G8UNP4|g__Bacteroides	4.662004662
+UniRef50_Q64NX2	4.6296296296
+UniRef50_Q64NX2|g__Bacteroides	4.6296296296
+UniRef50_E6SNW2	4.5662100457
+UniRef50_E6SNW2|g__Bacteroides	4.5662100456
+UniRef50_R5M4C8	4.4444444444
+UniRef50_R5M4C8|g__Bacteroides	4.4444444444
+UniRef50_R5RJG0	4.4444444444
+UniRef50_R5RJG0|g__Bacteroides	4.4444444444
+UniRef50_A9B436: 30S ribosomal protein S4	4.3859649123
+UniRef50_A9B436: 30S ribosomal protein S4|g__Bacteroides	4.3859649123
+UniRef50_D6D2K4: Putative fluoride ion transporter CrcB	4.3859649123
+UniRef50_D6D2K4: Putative fluoride ion transporter CrcB|g__Bacteroides	4.3859649123
+UniRef50_Q5LG50: Dephospho-CoA kinase	4.3010752688
+UniRef50_Q5LG50: Dephospho-CoA kinase|g__Bacteroides	4.3010752688
+UniRef50_Q8A8Q0	4.2735042735
+UniRef50_Q8A8Q0|g__Bacteroides	4.2735042735
+UniRef50_R5JC25: 5-formyltetrahydrofolate cyclo-ligase	4.2735042735
+UniRef50_R5JC25: 5-formyltetrahydrofolate cyclo-ligase|g__Bacteroides	4.2735042735
+UniRef50_Q8AB79: Excisionase	4.2553191489
+UniRef50_Q8AB79: Excisionase|g__Bacteroides	4.2553191489
+UniRef50_I3YK46: Bacteroides conjugative transposon TraK protein	4.2194092827
+UniRef50_I3YK46: Bacteroides conjugative transposon TraK protein|g__Bacteroides	4.2194092827
+UniRef50_R5RND9	4.2194092827
+UniRef50_R5RND9|g__Bacteroides	4.2194092827
+UniRef50_Q2S3P1: 30S ribosomal protein S11	4.1666666667
+UniRef50_Q2S3P1: 30S ribosomal protein S11|g__Bacteroides	4.1666666667
+UniRef50_Q650G4	4.1666666667
+UniRef50_Q650G4|g__Bacteroides	4.1666666667
+UniRef50_Q89AX0: Electron transport complex subunit A	4.0671134421
+UniRef50_Q89AX0: Electron transport complex subunit A|g__Bacteroides	4.0671134421
+UniRef50_A6KZM8: Chloramphenicol acetyltransferase	4.0404040404
+UniRef50_A6KZM8: Chloramphenicol acetyltransferase|g__Bacteroides	4.0404040404
+UniRef50_I8UXY9	4.0404040404
+UniRef50_I8UXY9|g__Bacteroides	4.0404040404
+UniRef50_Q8A980	4.0160642570
+UniRef50_Q8A980|g__Bacteroides	4.016064257
+UniRef50_A6KYK1: Transposase	3.9840637450
+UniRef50_A6KYK1: Transposase|g__Bacteroides	3.984063745
+UniRef50_F0R8X8: Tetracycline regulation of excision, RteC	3.9682539683
+UniRef50_F0R8X8: Tetracycline regulation of excision, RteC|g__Bacteroides	3.9682539683
+UniRef50_R6ZRN7	3.9482291375
+UniRef50_R6ZRN7|g__Bacteroides	3.9482291375
+UniRef50_R7JJL0: 4-phosphoerythronate dehydrogenase	3.8910505837
+UniRef50_R7JJL0: 4-phosphoerythronate dehydrogenase|g__Bacteroides	3.8910505836
+UniRef50_R6LA73: Pentapeptide repeat protein	3.8761000124
+UniRef50_R6LA73: Pentapeptide repeat protein|g__Bacteroides	3.8761000124000002
+UniRef50_R6FL32	3.8535645472
+UniRef50_R6FL32|g__Bacteroides	3.8535645472
+UniRef50_C9KYM2	3.8314176245
+UniRef50_C9KYM2|g__Bacteroides	3.8314176245
+UniRef50_R7NYP7: KDPG and KHG aldolase	3.8314176245
+UniRef50_R7NYP7: KDPG and KHG aldolase|g__Bacteroides	3.8314176245
+UniRef50_R5JQ93	3.7878787879
+UniRef50_R5JQ93|g__Bacteroides	3.7878787879
+UniRef50_F0R3P4: Conjugate transposon protein	3.7453183521
+UniRef50_F0R3P4: Conjugate transposon protein|g__Bacteroides	3.7453183521
+UniRef50_R5UTE7	3.7453183521
+UniRef50_R5UTE7|g__Bacteroides	3.7453183521
+UniRef50_R6B0U5	3.6630036630
+UniRef50_R6B0U5|g__Bacteroides	3.663003663
+UniRef50_F0R927: Phosphate-specific transport system accessory protein PhoU	3.6312112825
+UniRef50_F0R927: Phosphate-specific transport system accessory protein PhoU|g__Bacteroides	3.6312112825
+UniRef50_Q8A8Q5: Transposase	3.6231884058
+UniRef50_Q8A8Q5: Transposase|g__Bacteroides	3.6231884058
+UniRef50_Q8A9S1: 2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase	3.6231884058
+UniRef50_Q8A9S1: 2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase|g__Bacteroides	3.6231884058
+UniRef50_R6J655	3.6140979689
+UniRef50_R6J655|g__Bacteroides	3.6140979689
+UniRef50_A6KYA8	3.5815057073
+UniRef50_A6KYA8|g__Bacteroides	3.5815057073
+UniRef50_A6KXA8: Transposase	3.5587188612
+UniRef50_A6KXA8: Transposase|g__Bacteroides	3.5587188612
+UniRef50_R5CEL5: Electron transport complex subunit D	3.5587188612
+UniRef50_R5CEL5: Electron transport complex subunit D|g__Bacteroides	3.5587188612
+UniRef50_Q8A268	3.5587188612
+UniRef50_Q8A268|g__Bacteroides	3.5587188612
+UniRef50_P61913: Deoxyuridine 5'-triphosphate nucleotidohydrolase	3.5460992908
+UniRef50_P61913: Deoxyuridine 5'-triphosphate nucleotidohydrolase|g__Bacteroides	3.5460992908
+UniRef50_Q73WG1: Serine hydroxymethyltransferase	3.5366931919
+UniRef50_Q73WG1: Serine hydroxymethyltransferase|g__Bacteroides	3.5366931919
+UniRef50_F9D7B9: ISPg5 transposase Orf2	3.5087719298
+UniRef50_F9D7B9: ISPg5 transposase Orf2|g__Bacteroides	3.5087719298
+UniRef50_Q67JV0: 50S ribosomal protein L16	3.5087719298
+UniRef50_Q67JV0: 50S ribosomal protein L16|g__Bacteroides	3.5087719298
+UniRef50_R5BFK2: Hsp20/alpha crystallin family protein	3.5087719298
+UniRef50_R5BFK2: Hsp20/alpha crystallin family protein|g__Bacteroides	3.5087719298
+UniRef50_R5KHY4: 2-oxoglutarate:acceptor oxidoreductase subunit OorB	3.5006214724
+UniRef50_R5KHY4: 2-oxoglutarate:acceptor oxidoreductase subunit OorB|g__Bacteroides	3.5006214723
+UniRef50_R7KL41	3.4722222222
+UniRef50_R7KL41|g__Bacteroides	3.4722222222
+UniRef50_Q8A6E2	3.4364261168
+UniRef50_Q8A6E2|g__Bacteroides	3.4364261168
+UniRef50_A6L0N6: Conserved protein found in conjugate transposon	3.4018488003
+UniRef50_A6L0N6: Conserved protein found in conjugate transposon|g__Bacteroides	3.4018488003
+UniRef50_Q8A8J6: Glyoxalase family-like protein	3.4013605442
+UniRef50_Q8A8J6: Glyoxalase family-like protein|g__Bacteroides	3.4013605442
+UniRef50_A6L552: DNA repair protein	3.3670033670
+UniRef50_A6L552: DNA repair protein|g__Bacteroides	3.367003367
+UniRef50_F3ZPA3: Transcriptional regulator, MarR family	3.3670033670
+UniRef50_F3ZPA3: Transcriptional regulator, MarR family|g__Bacteroides	3.367003367
+UniRef50_R5NGD9	3.3670033670
+UniRef50_R5NGD9|g__Bacteroides	3.367003367
+UniRef50_P38674: Ketol-acid reductoisomerase, mitochondrial	3.3557046980
+UniRef50_P38674: Ketol-acid reductoisomerase, mitochondrial|g__Bacteroides	3.355704698
+UniRef50_Q8A4J1	3.3333333333
+UniRef50_Q8A4J1|g__Bacteroides	3.3333333333
+UniRef50_R5K2Q8	3.3286136573
+UniRef50_R5K2Q8|g__Bacteroides	3.3286136572
+UniRef50_G9S1V7	3.3085194376
+UniRef50_G9S1V7|g__Bacteroides	3.3085194376
+UniRef50_Q8A7E3	3.3003300330
+UniRef50_Q8A7E3|g__Bacteroides	3.300330033
+UniRef50_Q5LAB4: 3-isopropylmalate dehydrogenase	3.2967112501
+UniRef50_Q5LAB4: 3-isopropylmalate dehydrogenase|g__Bacteroides	3.2967112501
+UniRef50_O83553: Pyrophosphate--fructose 6-phosphate 1-phosphotransferase	3.2799134236
+UniRef50_O83553: Pyrophosphate--fructose 6-phosphate 1-phosphotransferase|g__Bacteroides	3.2799134236
+UniRef50_P0AC90: GDP-mannose 4,6-dehydratase	3.2397937988
+UniRef50_P0AC90: GDP-mannose 4,6-dehydratase|g__Bacteroides	3.2397937989
+UniRef50_A6KYW4	3.2362459547
+UniRef50_A6KYW4|g__Bacteroides	3.2362459547
+UniRef50_B0NTK8	3.2362459547
+UniRef50_B0NTK8|g__Bacteroides	3.2362459547
+UniRef50_W0F5J4: Phosphonate ABC transporter ATP-binding protein	3.2206119163
+UniRef50_W0F5J4: Phosphonate ABC transporter ATP-binding protein|g__Bacteroides	3.2206119163
+UniRef50_G8UMN4: Prephenate dehydrogenase	3.2051282051
+UniRef50_G8UMN4: Prephenate dehydrogenase|g__Bacteroides	3.2051282052
+UniRef50_R6SFG3	3.2051282051
+UniRef50_R6SFG3|g__Bacteroides	3.2051282051
+UniRef50_R7EPN1: C_GCAxxG_C_C family protein	3.2051282051
+UniRef50_R7EPN1: C_GCAxxG_C_C family protein|g__Bacteroides	3.2051282051
+UniRef50_E1WLE0	3.1976075454
+UniRef50_E1WLE0|g__Bacteroides	3.1976075454000004
+UniRef50_H1Y602: AMP nucleosidase	3.1897926635
+UniRef50_H1Y602: AMP nucleosidase|g__Bacteroides	3.1897926635
+UniRef50_A6LCB6: Nucleoside diphosphate kinase	3.1746031746
+UniRef50_A6LCB6: Nucleoside diphosphate kinase|g__Bacteroides	3.1746031746
+UniRef50_B3ESB4: Transcription elongation factor GreA	3.1746031746
+UniRef50_B3ESB4: Transcription elongation factor GreA|g__Bacteroides	3.1746031746
+UniRef50_D6CYB8: Transcriptional regulator, AsnC family	3.1746031746
+UniRef50_D6CYB8: Transcriptional regulator, AsnC family|g__Bacteroides	3.1746031746
+UniRef50_R5CNZ4	3.1746031746
+UniRef50_R5CNZ4|g__Bacteroides	3.1746031746
+UniRef50_R7D088: Competence-damage inducible protein	3.1446540881
+UniRef50_R7D088: Competence-damage inducible protein|g__Bacteroides	3.1446540881
+UniRef50_E6SQ70	3.1152647975
+UniRef50_E6SQ70|g__Bacteroides	3.1152647975
+UniRef50_R6KN92	3.0959752322
+UniRef50_R6KN92|g__Bacteroides	3.0959752322
+UniRef50_R7EKD0	3.0864197531
+UniRef50_R7EKD0|g__Bacteroides	3.0864197531
+UniRef50_R7HMB1	3.0864197531
+UniRef50_R7HMB1|g__Bacteroides	3.0864197531
+UniRef50_R6A3L9	3.0581039755
+UniRef50_R6A3L9|g__Bacteroides	3.0581039755
+UniRef50_R7NQ15: Gluconate 5-dehydrogenase	3.0581039755
+UniRef50_R7NQ15: Gluconate 5-dehydrogenase|g__Bacteroides	3.0581039755
+UniRef50_R5ALC1	3.0303030303
+UniRef50_R5ALC1|g__Bacteroides	3.0303030303000003
+UniRef50_R6BED5	3.0303030303
+UniRef50_R6BED5|g__Bacteroides	3.0303030303
+UniRef50_X5D7K7: Transcriptional regulator	3.0303030303
+UniRef50_X5D7K7: Transcriptional regulator|g__Bacteroides	3.0303030303
+UniRef50_R6C5B4: 3'(2') 5'-bisphosphate nucleotidase	3.0235715167
+UniRef50_R6C5B4: 3'(2') 5'-bisphosphate nucleotidase|g__Bacteroides	3.0235715166999997
+UniRef50_E1WS50: Ferritin	3.0030030030
+UniRef50_E1WS50: Ferritin|g__Bacteroides	3.003003003
+UniRef50_E6SQW3	2.9761904762
+UniRef50_E6SQW3|g__Bacteroides	2.9761904762
+UniRef50_A6KYS6: S-ribosylhomocysteine lyase	2.9498525074
+UniRef50_A6KYS6: S-ribosylhomocysteine lyase|g__Bacteroides	2.9498525074
+UniRef50_F2KU88: Acyltransferase	2.9498525074
+UniRef50_F2KU88: Acyltransferase|g__Bacteroides	2.9498525074
+UniRef50_Q8A4R1	2.9498525074
+UniRef50_Q8A4R1|g__Bacteroides	2.9498525074
+UniRef50_A0M572: 50S ribosomal protein L17	2.9239766082
+UniRef50_A0M572: 50S ribosomal protein L17|g__Bacteroides	2.9239766082
+UniRef50_A5FAU9: Phosphodiesterase, MJ0936 family	2.9239766082
+UniRef50_A5FAU9: Phosphodiesterase, MJ0936 family|g__Bacteroides	2.9239766082
+UniRef50_R5W452	2.8985507246
+UniRef50_R5W452|g__Bacteroides	2.8985507246
+UniRef50_Q64XV3	2.8735632184
+UniRef50_Q64XV3|g__Bacteroides	2.8735632184
+UniRef50_Q8A392	2.8735632184
+UniRef50_Q8A392|g__Bacteroides	2.8735632184
+UniRef50_R6JAQ7	2.8735632184
+UniRef50_R6JAQ7|g__Bacteroides	2.8735632184
+UniRef50_R6Y8G9: Phosphate ABC transporter permease protein PstC	2.8653295129
+UniRef50_R6Y8G9: Phosphate ABC transporter permease protein PstC|g__Bacteroides	2.8653295129
+UniRef50_U5Q7A5: Spore coat polysaccharide biosynthesis protein spsK	2.8490548808
+UniRef50_U5Q7A5: Spore coat polysaccharide biosynthesis protein spsK|g__Bacteroides	2.8490548808
+UniRef50_Q8A9U9: ATP synthase subunit b	2.8490028490
+UniRef50_Q8A9U9: ATP synthase subunit b|g__Bacteroides	2.849002849
+UniRef50_F3ZTK2: Alkyl hydroperoxide reductase/ Thiol specific antioxidant/ Mal allergen	2.8248587571
+UniRef50_F3ZTK2: Alkyl hydroperoxide reductase/ Thiol specific antioxidant/ Mal allergen|g__Bacteroides	2.8248587571
+UniRef50_Q89YJ6: Histone-like bacterial DNA-binding protein	2.8248587571
+UniRef50_Q89YJ6: Histone-like bacterial DNA-binding protein|g__Bacteroides	2.8248587571
+UniRef50_Q8A8J1: Glycoside transferase family 2	2.8129395218
+UniRef50_Q8A8J1: Glycoside transferase family 2|g__Bacteroides	2.8129395218
+UniRef50_E6SWE8: Integrase family protein	2.8117442782
+UniRef50_E6SWE8: Integrase family protein|g__Bacteroides	2.8117442782
+UniRef50_R7EKK1: Sigma-70 family RNA polymerase sigma factor	2.7777777778
+UniRef50_R7EKK1: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides	2.7777777778
+UniRef50_R7NKV2: Sigma-70 family RNA polymerase sigma factor	2.7777777778
+UniRef50_R7NKV2: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides	2.7777777778
+UniRef50_F0R5K9	2.7624309392
+UniRef50_F0R5K9|g__Bacteroides	2.7624309392
+UniRef50_E4T6S0	2.7599640775
+UniRef50_E4T6S0|g__Bacteroides	2.7599640775
+UniRef50_Q8D1X9: Phosphoenolpyruvate carboxykinase [ATP]	2.7434842250
+UniRef50_Q8D1X9: Phosphoenolpyruvate carboxykinase [ATP]|g__Bacteroides	2.7434842249
+UniRef50_R5J495	2.7434842250
+UniRef50_R5J495|g__Bacteroides	2.743484225
+UniRef50_R5U1K5: TonB family domain-containing protein	2.7434842250
+UniRef50_R5U1K5: TonB family domain-containing protein|g__Bacteroides	2.743484225
+UniRef50_R6A758: Purine or other phosphorylase family 1	2.7434842250
+UniRef50_R6A758: Purine or other phosphorylase family 1|g__Bacteroides	2.743484225
+UniRef50_R6ZQ01	2.7372989330
+UniRef50_R6ZQ01|g__Bacteroides	2.7372989329
+UniRef50_D9RT31: Outer membrane protein	2.7322404372
+UniRef50_D9RT31: Outer membrane protein|g__Bacteroides	2.7322404372
+UniRef50_F0R3Q0: Relaxase/mobilization nuclease family protein	2.7322404372
+UniRef50_F0R3Q0: Relaxase/mobilization nuclease family protein|g__Bacteroides	2.7322404372
+UniRef50_R5S3H1: Relaxase/mobilization nuclease domain protein	2.7322404372
+UniRef50_R5S3H1: Relaxase/mobilization nuclease domain protein|g__Bacteroides	2.7322404372
+UniRef50_B4SSU7: Nitrilase/cyanide hydratase and apolipoprotein N-acyltransferase	2.7210884354
+UniRef50_B4SSU7: Nitrilase/cyanide hydratase and apolipoprotein N-acyltransferase|g__Bacteroides	2.7210884354
+UniRef50_R6RT35	2.7173913043
+UniRef50_R6RT35|g__Bacteroides	2.7173913043
+UniRef50_Q8A4L6	2.7100271003
+UniRef50_Q8A4L6|g__Bacteroides	2.7100271003
+UniRef50_R5ND35	2.7100271003
+UniRef50_R5ND35|g__Bacteroides	2.7100271003
+UniRef50_R6JCU1: Glutaminase A	2.7100271003
+UniRef50_R6JCU1: Glutaminase A|g__Bacteroides	2.7100271003
+UniRef50_R7PA29: Malonyl CoA-acyl carrier protein transacylase	2.7100271003
+UniRef50_R7PA29: Malonyl CoA-acyl carrier protein transacylase|g__Bacteroides	2.7100271003
+UniRef50_R6AI91: Conserved domain protein	2.6954177898
+UniRef50_R6AI91: Conserved domain protein|g__Bacteroides	2.6954177898
+UniRef50_F0R2U7: Integrase catalytic region	2.6881720430
+UniRef50_F0R2U7: Integrase catalytic region|g__Bacteroides	2.688172043
+UniRef50_B5Y9A7: Glutamate formiminotransferase	2.6773761714
+UniRef50_B5Y9A7: Glutamate formiminotransferase|g__Bacteroides	2.6773761714
+UniRef50_R5S1C6: 5-methyltetrahydrofolate-homocysteine methyltransferase	2.6560424967
+UniRef50_R5S1C6: 5-methyltetrahydrofolate-homocysteine methyltransferase|g__Bacteroides	2.6560424967
+UniRef50_Q4UY06: Sulfate adenylyltransferase subunit 2	2.6298590147
+UniRef50_Q4UY06: Sulfate adenylyltransferase subunit 2|g__Bacteroides	2.6298590147
+UniRef50_R5JSP7	2.6143790850
+UniRef50_R5JSP7|g__Bacteroides	2.614379085
+UniRef50_R7P593	2.6041666667
+UniRef50_R7P593|g__Bacteroides	2.6041666667
+UniRef50_R5WCH7: Transcriptional regulator AraC family	2.5940337224
+UniRef50_R5WCH7: Transcriptional regulator AraC family|g__Bacteroides	2.5940337224
+UniRef50_Q5L9P4: Ribosome maturation factor RimM	2.5839793282
+UniRef50_Q5L9P4: Ribosome maturation factor RimM|g__Bacteroides	2.5839793282
+UniRef50_Q8AA15: Phosphomethylpyrimidine synthase	2.5839793282
+UniRef50_Q8AA15: Phosphomethylpyrimidine synthase|g__Bacteroides	2.5839793282
+UniRef50_Q8ABT6: Transposase	2.5839793282
+UniRef50_Q8ABT6: Transposase|g__Bacteroides	2.5839793282
+UniRef50_R5AL72	2.5839793282
+UniRef50_R5AL72|g__Bacteroides	2.5839793282
+UniRef50_R5F165	2.5839793282
+UniRef50_R5F165|g__Bacteroides	2.5839793282
+UniRef50_R6ARZ0	2.5839793282
+UniRef50_R6ARZ0|g__Bacteroides	2.5839793282
+UniRef50_R6AK47: Peptidase M16 inactive domain protein	2.5839793282
+UniRef50_R6AK47: Peptidase M16 inactive domain protein|g__Bacteroides	2.5839793282
+UniRef50_R7LCU5: Transcription elongation factor NusA	2.5641025641
+UniRef50_R7LCU5: Transcription elongation factor NusA|g__Bacteroides	2.5641025641
+UniRef50_R7CVV2: Alpha-N-arabinofuranosidase	2.5641025641
+UniRef50_R7CVV2: Alpha-N-arabinofuranosidase|g__Bacteroides	2.5641025641
+UniRef50_R6JDG7	2.5591810621
+UniRef50_R6JDG7|g__Bacteroides	2.5591810621
+UniRef50_R5DDM9	2.5378261541
+UniRef50_R5DDM9|g__Bacteroides	2.5378261541000002
+UniRef50_Q8A8P1: Mobilization protein BmgA	2.5354407377
+UniRef50_Q8A8P1: Mobilization protein BmgA|g__Bacteroides	2.5354407377
+UniRef50_R5S2U5: Ribose-phosphate pyrophosphokinase	2.5348542459
+UniRef50_R5S2U5: Ribose-phosphate pyrophosphokinase|g__Bacteroides	2.5348542459
+UniRef50_D6D2H7: Relaxase/Mobilisation nuclease domain	2.5252525253
+UniRef50_D6D2H7: Relaxase/Mobilisation nuclease domain|g__Bacteroides	2.5252525253
+UniRef50_Q8AB84	2.5252525253
+UniRef50_Q8AB84|g__Bacteroides	2.5252525253
+UniRef50_A6KWE7: RNA polymerase ECF-type sigma factor	2.5062656642
+UniRef50_A6KWE7: RNA polymerase ECF-type sigma factor|g__Bacteroides	2.5062656642
+UniRef50_R6STZ2: Sigma-70 region 2	2.5062656642
+UniRef50_R6STZ2: Sigma-70 region 2|g__Bacteroides	2.5062656642
+UniRef50_R6JI98: Dihydrolipoyl dehydrogenase	2.5001243843
+UniRef50_R6JI98: Dihydrolipoyl dehydrogenase|g__Bacteroides	2.5001243843000003
+UniRef50_A6GZ94: 50S ribosomal protein L22	2.5000000000
+UniRef50_A6GZ94: 50S ribosomal protein L22|g__Bacteroides	2.5
+UniRef50_R7ACY8: Dyp-type peroxidase	2.4968789014
+UniRef50_R7ACY8: Dyp-type peroxidase|g__Bacteroides	2.4968789014
+UniRef50_E6SVE9: GCN5-related N-acetyltransferase	2.4875621891
+UniRef50_E6SVE9: GCN5-related N-acetyltransferase|g__Bacteroides	2.4875621891
+UniRef50_R6BST1: 2-oxoglutarate oxidoreductase gamma subunit	2.4875621891
+UniRef50_R6BST1: 2-oxoglutarate oxidoreductase gamma subunit|g__Bacteroides	2.4875621891
+UniRef50_R6DHP0	2.4875621891
+UniRef50_R6DHP0|g__Bacteroides	2.4875621891
+UniRef50_R6JH83	2.4875621891
+UniRef50_R6JH83|g__Bacteroides	2.4875621891
+UniRef50_R7E540	2.4875621891
+UniRef50_R7E540|g__Bacteroides	2.4875621891
+UniRef50_D5EYI2: Maltodextrin phosphorylase	2.4844720497
+UniRef50_D5EYI2: Maltodextrin phosphorylase|g__Bacteroides	2.4844720497
+UniRef50_F0R4F1: DNA topoisomerase	2.4794813435
+UniRef50_F0R4F1: DNA topoisomerase|g__Bacteroides	2.4794813435
+UniRef50_Q5LJ70: tRNA-2-methylthio-N(6)-dimethylallyladenosine synthase	2.4630541872
+UniRef50_Q5LJ70: tRNA-2-methylthio-N(6)-dimethylallyladenosine synthase|g__Bacteroides	2.4630541872
+UniRef50_B2RJD7: Translation initiation factor IF-3	2.4509803922
+UniRef50_B2RJD7: Translation initiation factor IF-3|g__Bacteroides	2.4509803922
+UniRef50_Q8A8I0: Transcriptional regulator	2.4509803922
+UniRef50_Q8A8I0: Transcriptional regulator|g__Bacteroides	2.4509803922
+UniRef50_R6KQ62	2.4330900243
+UniRef50_R6KQ62|g__Bacteroides	2.4330900243
+UniRef50_R7KLA8	2.4295549634
+UniRef50_R7KLA8|g__Bacteroides	2.4295549634
+UniRef50_D6D0X5: Translation factor SUA5	2.4154589372
+UniRef50_D6D0X5: Translation factor SUA5|g__Bacteroides	2.4154589372
+UniRef50_R6ILE4	2.4154589372
+UniRef50_R6ILE4|g__Bacteroides	2.4154589372
+UniRef50_A7NLF0: Transport system permease protein	2.4067388688
+UniRef50_A7NLF0: Transport system permease protein|g__Bacteroides	2.4067388688
+UniRef50_P26830: Putative peroxiredoxin in ndh 5'region (Fragment)	2.3980815348
+UniRef50_P26830: Putative peroxiredoxin in ndh 5'region (Fragment)|g__Bacteroides	2.3980815348
+UniRef50_R6E7T4: Glycosyltransferase group 4 family	2.3809523810
+UniRef50_R6E7T4: Glycosyltransferase group 4 family|g__Bacteroides	2.380952381
+UniRef50_F0R4S9: Copper amine oxidase domain-containing protein	2.3724792408
+UniRef50_F0R4S9: Copper amine oxidase domain-containing protein|g__Bacteroides	2.3724792408
+UniRef50_Q2RKK1: Xanthine phosphoribosyltransferase	2.3640661939
+UniRef50_Q2RKK1: Xanthine phosphoribosyltransferase|g__Bacteroides	2.3640661939
+UniRef50_R6AZR7: Transcription termination/antitermination factor NusG	2.3640661939
+UniRef50_R6AZR7: Transcription termination/antitermination factor NusG|g__Bacteroides	2.3640661939
+UniRef50_R7CUN8: RNA polymerase ECF-type sigma factor	2.3640661939
+UniRef50_R7CUN8: RNA polymerase ECF-type sigma factor|g__Bacteroides	2.3640661939
+UniRef50_R6VGJ6	2.3529411765
+UniRef50_R6VGJ6|g__Bacteroides	2.3529411765
+UniRef50_R7DIF4: NodT family efflux transporter outer membrane factor (OMF) lipoprotein	2.3516696482
+UniRef50_R7DIF4: NodT family efflux transporter outer membrane factor (OMF) lipoprotein|g__Bacteroides	2.3516696482
+UniRef50_G4QII0: D-isomer specific 2-hydroxyacid dehydrogenase, NAD-binding protein	2.3474178404
+UniRef50_G4QII0: D-isomer specific 2-hydroxyacid dehydrogenase, NAD-binding protein|g__Bacteroides	2.3474178404
+UniRef50_R7ELF1	2.3310023310
+UniRef50_R7ELF1|g__Bacteroides	2.331002331
+UniRef50_T2N9I9: Conjugative transposon TraJ protein	2.3269980507
+UniRef50_T2N9I9: Conjugative transposon TraJ protein|g__Bacteroides	2.3269980507000003
+UniRef50_R7KL80	2.3228803717
+UniRef50_R7KL80|g__Bacteroides	2.3228803717
+UniRef50_R6L7C1: Bacterial transferase hexapeptide repeat protein	2.3148148148
+UniRef50_R6L7C1: Bacterial transferase hexapeptide repeat protein|g__Bacteroides	2.3148148148
+UniRef50_Q89ZT0: MscS mechanosensitive ion channel	2.3081592231
+UniRef50_Q89ZT0: MscS mechanosensitive ion channel|g__Bacteroides	2.3081592231
+UniRef50_A7UZY6	2.2988505747
+UniRef50_A7UZY6|g__Bacteroides	2.2988505747
+UniRef50_R5JK49: Cyclic nucleotide-binding domain-containing protein	2.2988505747
+UniRef50_R5JK49: Cyclic nucleotide-binding domain-containing protein|g__Bacteroides	2.2988505747
+UniRef50_R5UR02	2.2988505747
+UniRef50_R5UR02|g__Bacteroides	2.2988505747
+UniRef50_R5VAH1	2.2988505747
+UniRef50_R5VAH1|g__Bacteroides	2.2988505747
+UniRef50_R7J8P5	2.2988505747
+UniRef50_R7J8P5|g__Bacteroides	2.2988505747
+UniRef50_W0EU49: Molecular chaperone DnaJ	2.2831050228
+UniRef50_W0EU49: Molecular chaperone DnaJ|g__Bacteroides	2.2831050228
+UniRef50_F9D752	2.2675736961
+UniRef50_F9D752|g__Bacteroides	2.2675736961
+UniRef50_Q8A6Z7: RNA polymerase ECF-type sigma factor	2.2675736961
+UniRef50_Q8A6Z7: RNA polymerase ECF-type sigma factor|g__Bacteroides	2.2675736961
+UniRef50_R5C4Q9	2.2675736961
+UniRef50_R5C4Q9|g__Bacteroides	2.2675736961
+UniRef50_A6L2I3: Phenylalanine--tRNA ligase alpha subunit	2.2611652223
+UniRef50_A6L2I3: Phenylalanine--tRNA ligase alpha subunit|g__Bacteroides	2.2611652223
+UniRef50_R5CA64: Phosphate-selective porin O and P	2.2601207441
+UniRef50_R5CA64: Phosphate-selective porin O and P|g__Bacteroides	2.2601207441
+UniRef50_R6LK37: Inosine-5'-monophosphate dehydrogenase	2.2528619174
+UniRef50_R6LK37: Inosine-5'-monophosphate dehydrogenase|g__Bacteroides	2.2528619173999997
+UniRef50_Q5LG55: 50S ribosomal protein L25	2.2522522523
+UniRef50_Q5LG55: 50S ribosomal protein L25|g__Bacteroides	2.2522522523
+UniRef50_B3EUK4: 50S ribosomal protein L15	2.2471910112
+UniRef50_B3EUK4: 50S ribosomal protein L15|g__Bacteroides	2.2471910112
+UniRef50_R5S0F4	2.2371364653
+UniRef50_R5S0F4|g__Bacteroides	2.2371364653
+UniRef50_P0A992: Fructose-bisphosphate aldolase class 1	2.2222222222
+UniRef50_P0A992: Fructose-bisphosphate aldolase class 1|g__Bacteroides	2.2222222222
+UniRef50_R5U9H7	2.2222222222
+UniRef50_R5U9H7|g__Bacteroides	2.2222222222
+UniRef50_R6JBG2: RNA polymerase ECF-type sigma factor	2.2075055188
+UniRef50_R6JBG2: RNA polymerase ECF-type sigma factor|g__Bacteroides	2.2075055188
+UniRef50_R6YIV5	2.2075055188
+UniRef50_R6YIV5|g__Bacteroides	2.2075055188
+UniRef50_P10172: Glutaminase-asparaginase	2.2002200220
+UniRef50_P10172: Glutaminase-asparaginase|g__Bacteroides	2.200220022
+UniRef50_Q8A749: Maf-like protein BT_1676	2.1978021978
+UniRef50_Q8A749: Maf-like protein BT_1676|g__Bacteroides	2.1978021978
+UniRef50_A6KXG9: Adenylyl-sulfate kinase	2.1929824561
+UniRef50_A6KXG9: Adenylyl-sulfate kinase|g__Bacteroides	2.1929824561
+UniRef50_R6K7N0	2.1929824561
+UniRef50_R6K7N0|g__Bacteroides	2.1929824561
+UniRef50_R6WTW9	2.1929824561
+UniRef50_R6WTW9|g__Bacteroides	2.1929824561
+UniRef50_R7EGB3	2.1929824561
+UniRef50_R7EGB3|g__Bacteroides	2.1929824561
+UniRef50_D4IL09: Transposase and inactivated derivatives	2.1880693142
+UniRef50_D4IL09: Transposase and inactivated derivatives|g__Bacteroides	2.1880693142
+UniRef50_B0NV90	2.1786492375
+UniRef50_B0NV90|g__Bacteroides	2.1786492375
+UniRef50_R5JKC4	2.1786492375
+UniRef50_R5JKC4|g__Bacteroides	2.1786492375
+UniRef50_R6D686: MgtC family protein	2.1786492375
+UniRef50_R6D686: MgtC family protein|g__Bacteroides	2.1786492375
+UniRef50_R7KG28: PHP domain-containing protein	2.1715526602
+UniRef50_R7KG28: PHP domain-containing protein|g__Bacteroides	2.1715526602
+UniRef50_F0R8Z2	2.1645021645
+UniRef50_F0R8Z2|g__Bacteroides	2.1645021645
+UniRef50_R5UXB6	2.1645021645
+UniRef50_R5UXB6|g__Bacteroides	2.1645021645
+UniRef50_Q7W4T6: Holliday junction ATP-dependent DNA helicase RuvB	2.1625934324
+UniRef50_Q7W4T6: Holliday junction ATP-dependent DNA helicase RuvB|g__Bacteroides	2.1625934325
+UniRef50_R5USW4	2.1505376344
+UniRef50_R5USW4|g__Bacteroides	2.1505376344
+UniRef50_D2QJ16: Fumarylacetoacetate (FAA) hydrolase	2.1367521368
+UniRef50_D2QJ16: Fumarylacetoacetate (FAA) hydrolase|g__Bacteroides	2.1367521368
+UniRef50_F5J219	2.1367521368
+UniRef50_F5J219|g__Bacteroides	2.1367521368
+UniRef50_R5I8Z9	2.1367521368
+UniRef50_R5I8Z9|g__Bacteroides	2.1367521368
+UniRef50_Q5LFT6: Aminomethyltransferase	2.1231422505
+UniRef50_Q5LFT6: Aminomethyltransferase|g__Bacteroides	2.1231422505
+UniRef50_R7JCR6	2.1231422505
+UniRef50_R7JCR6|g__Bacteroides	2.1231422505
+UniRef50_R5ETA7: Arylsulfatase	2.1097233820
+UniRef50_R5ETA7: Arylsulfatase|g__Bacteroides	2.1097233819
+UniRef50_R6JHE8: Efflux transporter RND family MFP subunit	2.1097046414
+UniRef50_R6JHE8: Efflux transporter RND family MFP subunit|g__Bacteroides	2.1097046414
+UniRef50_R5PE61	2.1063770315
+UniRef50_R5PE61|g__Bacteroides	2.1063770315
+UniRef50_E6STF3: CDP-alcohol phosphatidyltransferase	2.0833333333
+UniRef50_E6STF3: CDP-alcohol phosphatidyltransferase|g__Bacteroides	2.0833333333
+UniRef50_Q8AA13: Thiamine-phosphate synthase	2.0833333333
+UniRef50_Q8AA13: Thiamine-phosphate synthase|g__Bacteroides	2.0833333333
+UniRef50_R7DMI0	2.0833333333
+UniRef50_R7DMI0|g__Bacteroides	2.0833333333
+UniRef50_D6D0E8: Site-specific recombinase XerD	2.0768431983
+UniRef50_D6D0E8: Site-specific recombinase XerD|g__Bacteroides	2.0768431983
+UniRef50_A6L561: Transposase	2.0703933747
+UniRef50_A6L561: Transposase|g__Bacteroides	2.0703933747
+UniRef50_R7J8G7	2.0703933747
+UniRef50_R7J8G7|g__Bacteroides	2.0703933747
+UniRef50_F9Z3F4: Epidermal growth-factor receptor (EGFR) L domain	2.0607934055
+UniRef50_F9Z3F4: Epidermal growth-factor receptor (EGFR) L domain|g__Bacteroides	2.0607934055
+UniRef50_R6PW67: Bacterial sugar transferase	2.0576131687
+UniRef50_R6PW67: Bacterial sugar transferase|g__Bacteroides	2.0576131687
+UniRef50_R6Z2N6	2.0576131687
+UniRef50_R6Z2N6|g__Bacteroides	2.0576131687
+UniRef50_A6L3K9: DNA replication and repair protein RecF	2.0548378926
+UniRef50_A6L3K9: DNA replication and repair protein RecF|g__Bacteroides	2.0548378926
+UniRef50_Q5LI12: Orotate phosphoribosyltransferase	2.0449897751
+UniRef50_Q5LI12: Orotate phosphoribosyltransferase|g__Bacteroides	2.0449897751
+UniRef50_R6JGW7: Metallo-beta-lactamase domain protein	2.0449897751
+UniRef50_R6JGW7: Metallo-beta-lactamase domain protein|g__Bacteroides	2.0449897751
+UniRef50_R6JHB2	2.0449897751
+UniRef50_R6JHB2|g__Bacteroides	2.0449897751
+UniRef50_R7E1I3	2.0449897751
+UniRef50_R7E1I3|g__Bacteroides	2.0449897751
+UniRef50_A4CN78: Queuine tRNA-ribosyltransferase	2.0387359837
+UniRef50_A4CN78: Queuine tRNA-ribosyltransferase|g__Bacteroides	2.0387359836
+UniRef50_R5C552	2.0366598778
+UniRef50_R5C552|g__Bacteroides	2.0366598778
+UniRef50_Q5LFJ5: Pyridoxine/pyridoxamine 5'-phosphate oxidase	2.0325203252
+UniRef50_Q5LFJ5: Pyridoxine/pyridoxamine 5'-phosphate oxidase|g__Bacteroides	2.0325203252
+UniRef50_Q8A477: 50S ribosomal protein L4	2.0325203252
+UniRef50_Q8A477: 50S ribosomal protein L4|g__Bacteroides	2.0325203252
+UniRef50_R6MDV7: Conserved domain protein	2.0325203252
+UniRef50_R6MDV7: Conserved domain protein|g__Bacteroides	2.0325203252
+UniRef50_R6AC71: Formiminotransferase-cyclodeaminase	2.0242914980
+UniRef50_R6AC71: Formiminotransferase-cyclodeaminase|g__Bacteroides	2.024291498
+UniRef50_Q8A157: Putative endothelin-converting enzyme	2.0202020202
+UniRef50_Q8A157: Putative endothelin-converting enzyme|g__Bacteroides	2.0202020202
+UniRef50_R6S681	2.0202020202
+UniRef50_R6S681|g__Bacteroides	2.0202020202
+UniRef50_C7MNW3: Acyl-CoA synthetase (AMP-forming)/AMP-acid ligase II	2.0026720107
+UniRef50_C7MNW3: Acyl-CoA synthetase (AMP-forming)/AMP-acid ligase II|g__Bacteroides	2.0026720107
+UniRef50_R6Y770: Ribulose-phosphate 3-epimerase	1.9960079840
+UniRef50_R6Y770: Ribulose-phosphate 3-epimerase|g__Bacteroides	1.996007984
+UniRef50_A6LCK4: Galactokinase	1.9900497512
+UniRef50_A6LCK4: Galactokinase|g__Bacteroides	1.9900497512
+UniRef50_B7UZU0: Na(+)-translocating NADH-quinone reductase subunit D	1.9841269841
+UniRef50_B7UZU0: Na(+)-translocating NADH-quinone reductase subunit D|g__Bacteroides	1.9841269841
+UniRef50_R5W7K3	1.9841269841
+UniRef50_R5W7K3|g__Bacteroides	1.9841269841
+UniRef50_R6JEH2: CDP-diacylglycerol-glycerol-3-phosphate 3-phosphatidyltransferase-related protein	1.9841269841
+UniRef50_R6JEH2: CDP-diacylglycerol-glycerol-3-phosphate 3-phosphatidyltransferase-related protein|g__Bacteroides	1.9841269841
+UniRef50_R5GVY8	1.9782567859
+UniRef50_R5GVY8|g__Bacteroides	1.978256786
+UniRef50_Q8A800: Diaminopimelate decarboxylase	1.9782393670
+UniRef50_Q8A800: Diaminopimelate decarboxylase|g__Bacteroides	1.978239367
+UniRef50_T2KQD4: Na+-transporting methylmalonyl-CoA/oxaloacetate decarboxylase, beta subunit	1.9782393670
+UniRef50_T2KQD4: Na+-transporting methylmalonyl-CoA/oxaloacetate decarboxylase, beta subunit|g__Bacteroides	1.978239367
+UniRef50_Q7MWN8	1.9775890633
+UniRef50_Q7MWN8|g__Bacteroides	1.9775890633
+UniRef50_Q11SW8: Lipoprotein-releasing system ATP-binding protein LolD	1.9723865878
+UniRef50_Q11SW8: Lipoprotein-releasing system ATP-binding protein LolD|g__Bacteroides	1.9723865878
+UniRef50_R7CWN7: WbqC-like protein	1.9723865878
+UniRef50_R7CWN7: WbqC-like protein|g__Bacteroides	1.9723865878
+UniRef50_G8UL57: ATP-dependent DNA helicase RecQ	1.9680207521
+UniRef50_G8UL57: ATP-dependent DNA helicase RecQ|g__Bacteroides	1.9680207521000002
+UniRef50_R6HYK5: N-acetylglucosamine-6-phosphate deacetylase	1.9665683382
+UniRef50_R6HYK5: N-acetylglucosamine-6-phosphate deacetylase|g__Bacteroides	1.9665683382
+UniRef50_R6FG07: Transposase IS4 family	1.9637104004
+UniRef50_R6FG07: Transposase IS4 family|g__Bacteroides	1.9637104004000001
+UniRef50_Q8A861: L-Ala-D/L-Glu epimerase	1.9613951288
+UniRef50_Q8A861: L-Ala-D/L-Glu epimerase|g__Bacteroides	1.9613951288
+UniRef50_B0NU13: Glycosyltransferase, group 1 family protein	1.9607843137
+UniRef50_B0NU13: Glycosyltransferase, group 1 family protein|g__Bacteroides	1.9607843137
+UniRef50_B5F621: Mannonate dehydratase	1.9607843137
+UniRef50_B5F621: Mannonate dehydratase|g__Bacteroides	1.9607843137
+UniRef50_UPI000468D029: glutamine synthetase	1.9607843137
+UniRef50_UPI000468D029: glutamine synthetase|g__Bacteroides	1.9607843138
+UniRef50_R5AN19: NADH:ubiquinone oxidoreductase Na(+)-translocating B subunit	1.9550342131
+UniRef50_R5AN19: NADH:ubiquinone oxidoreductase Na(+)-translocating B subunit|g__Bacteroides	1.9550342131
+UniRef50_R6B574: Glycosyltransferase group 2 family protein	1.9550342131
+UniRef50_R6B574: Glycosyltransferase group 2 family protein|g__Bacteroides	1.9550342131
+UniRef50_A6LG36: Renin-binding protein-related protein	1.9493177388
+UniRef50_A6LG36: Renin-binding protein-related protein|g__Bacteroides	1.9493177388
+UniRef50_Q182G9: Uracil-DNA glycosylase	1.9493177388
+UniRef50_Q182G9: Uracil-DNA glycosylase|g__Bacteroides	1.9493177388
+UniRef50_R6E9G2: Phosphoenolpyruvate synthase	1.9447685725
+UniRef50_R6E9G2: Phosphoenolpyruvate synthase|g__Bacteroides	1.9447685725000001
+UniRef50_P0CJ82	1.9417475728
+UniRef50_P0CJ82|g__Bacteroides	1.9417475728
+UniRef50_F0R5I4	1.9267822736
+UniRef50_F0R5I4|g__Bacteroides	1.9267822736
+UniRef50_Q8ABT9	1.9267822736
+UniRef50_Q8ABT9|g__Bacteroides	1.9267822736
+UniRef50_Q8ABV6	1.9267822736
+UniRef50_Q8ABV6|g__Bacteroides	1.9267822736
+UniRef50_R5JVY0	1.9267822736
+UniRef50_R5JVY0|g__Bacteroides	1.9267822736
+UniRef50_E4T3Y0: Flavodoxin/nitric oxide synthase	1.9102196753
+UniRef50_E4T3Y0: Flavodoxin/nitric oxide synthase|g__Bacteroides	1.9102196753
+UniRef50_Q5LI41: Acetate kinase	1.9102196753
+UniRef50_Q5LI41: Acetate kinase|g__Bacteroides	1.9102196753
+UniRef50_E4TAG3: Ribosomal RNA small subunit methyltransferase I	1.9047619048
+UniRef50_E4TAG3: Ribosomal RNA small subunit methyltransferase I|g__Bacteroides	1.9047619048
+UniRef50_Q8A1G8: Acetate kinase	1.9047619048
+UniRef50_Q8A1G8: Acetate kinase|g__Bacteroides	1.9047619048
+UniRef50_L0G4L7: Response regulator with CheY-like receiver domain and winged-helix DNA-binding domain	1.8939393939
+UniRef50_L0G4L7: Response regulator with CheY-like receiver domain and winged-helix DNA-binding domain|g__Bacteroides	1.8939393939
+UniRef50_R5Y5R7: Nucleotide sugar dehydrogenase	1.8939393939
+UniRef50_R5Y5R7: Nucleotide sugar dehydrogenase|g__Bacteroides	1.8939393939
+UniRef50_I4AQY4: Argininosuccinate synthase	1.8885741265
+UniRef50_I4AQY4: Argininosuccinate synthase|g__Bacteroides	1.8885741265
+UniRef50_A6LGY9: Mobilization protein BmgB	1.8761726079
+UniRef50_A6LGY9: Mobilization protein BmgB|g__Bacteroides	1.8761726079
+UniRef50_R5GDB8: Radical SAM protein TIGR01212 family	1.8726591760
+UniRef50_R5GDB8: Radical SAM protein TIGR01212 family|g__Bacteroides	1.872659176
+UniRef50_A6LCF8: Glycoside hydrolase family 92	1.8682795076
+UniRef50_A6LCF8: Glycoside hydrolase family 92|g__Bacteroides	1.8682795077
+UniRef50_E6SSG1: Outer membrane efflux protein	1.8674136321
+UniRef50_E6SSG1: Outer membrane efflux protein|g__Bacteroides	1.8674136321
+UniRef50_F0S6F8: Glycosyl hydrolase family 88	1.8674136321
+UniRef50_F0S6F8: Glycosyl hydrolase family 88|g__Bacteroides	1.8674136321
+UniRef50_D6D8P2: Outer membrane transport energization protein TonB (TC 2.C.1.1.1)	1.8621973929
+UniRef50_D6D8P2: Outer membrane transport energization protein TonB (TC 2	1.8621973929
+UniRef50_Q5L9K4: Cytidylate kinase	1.8518518519
+UniRef50_Q5L9K4: Cytidylate kinase|g__Bacteroides	1.8518518519
+UniRef50_Q8A501: Integrase	1.8518518519
+UniRef50_Q8A501: Integrase|g__Bacteroides	1.8518518518
+UniRef50_R5JDA3: Hemolysin III family channel protein	1.8518518519
+UniRef50_R5JDA3: Hemolysin III family channel protein|g__Bacteroides	1.8518518519
+UniRef50_A6LB33: Haloacid dehalogenase-like hydrolase	1.8467220683
+UniRef50_A6LB33: Haloacid dehalogenase-like hydrolase|g__Bacteroides	1.8467220684
+UniRef50_R6RVA2	1.8467220683
+UniRef50_R6RVA2|g__Bacteroides	1.8467220683
+UniRef50_A6L6L6: Tyrosine type site-specific recombinase	1.8416206262
+UniRef50_A6L6L6: Tyrosine type site-specific recombinase|g__Bacteroides	1.8416206262
+UniRef50_R7EGW5	1.8416206262
+UniRef50_R7EGW5|g__Bacteroides	1.8416206262
+UniRef50_R5EV05	1.8382352941
+UniRef50_R5EV05|g__Bacteroides	1.8382352941
+UniRef50_Q64WK8	1.8365472911
+UniRef50_Q64WK8|g__Bacteroides	1.836547291
+UniRef50_A6LH06: Transposase	1.8315571255
+UniRef50_A6LH06: Transposase|g__Bacteroides	1.8315571255
+UniRef50_Q8A8H3: Outer membrane protein, OmpA family	1.8315018315
+UniRef50_Q8A8H3: Outer membrane protein, OmpA family|g__Bacteroides	1.8315018315
+UniRef50_R6JGH9: Flavodoxin-like protein	1.8315018315
+UniRef50_R6JGH9: Flavodoxin-like protein|g__Bacteroides	1.8315018315
+UniRef50_A1SEI7: 50S ribosomal protein L1	1.8214936248
+UniRef50_A1SEI7: 50S ribosomal protein L1|g__Bacteroides	1.8214936248
+UniRef50_I9A722	1.8214936248
+UniRef50_I9A722|g__Bacteroides	1.8214936248
+UniRef50_A6L0J2	1.8115942029
+UniRef50_A6L0J2|g__Bacteroides	1.8115942029
+UniRef50_Q9AE24: Transcriptional regulatory protein RprY	1.8115942029
+UniRef50_Q9AE24: Transcriptional regulatory protein RprY|g__Bacteroides	1.8115942029
+UniRef50_R5P0L2	1.8115942029
+UniRef50_R5P0L2|g__Bacteroides	1.8115942029
+UniRef50_R6ADR4: PHP domain protein	1.8115942029
+UniRef50_R6ADR4: PHP domain protein|g__Bacteroides	1.8115942029
+UniRef50_R6X7L9	1.8115942029
+UniRef50_R6X7L9|g__Bacteroides	1.8115942029
+UniRef50_F2KXD1: Chromate transport protein	1.8018018018
+UniRef50_F2KXD1: Chromate transport protein|g__Bacteroides	1.8018018018
+UniRef50_R5AUC0: Succinate dehydrogenase cytochrome B subunit b558 family	1.8018018018
+UniRef50_R5AUC0: Succinate dehydrogenase cytochrome B subunit b558 family|g__Bacteroides	1.8018018018
+UniRef50_R5KU63	1.8018018018
+UniRef50_R5KU63|g__Bacteroides	1.8018018018
+UniRef50_R6JE33	1.7969451932
+UniRef50_R6JE33|g__Bacteroides	1.7969451932
+UniRef50_R6YJT2: Glycosyl transferase group 1 family	1.7921146953
+UniRef50_R6YJT2: Glycosyl transferase group 1 family|g__Bacteroides	1.7921146953
+UniRef50_Q2S6J2: Uridylate kinase	1.7825311943
+UniRef50_Q2S6J2: Uridylate kinase|g__Bacteroides	1.7825311943
+UniRef50_R6UWR2	1.7825311943
+UniRef50_R6UWR2|g__Bacteroides	1.7825311943
+UniRef50_R7CUQ3	1.7801544860
+UniRef50_R7CUQ3|g__Bacteroides	1.780154486
+UniRef50_R6JP42: Outer membrane efflux protein	1.7777777778
+UniRef50_R6JP42: Outer membrane efflux protein|g__Bacteroides	1.7777777778
+UniRef50_R6FEU3: Chloramphenicol O-acetyltransferase	1.7730496454
+UniRef50_R6FEU3: Chloramphenicol O-acetyltransferase|g__Bacteroides	1.7730496454
+UniRef50_R6L4U7: Lipoyltransferase and lipoate-protein ligase	1.7543859649
+UniRef50_R6L4U7: Lipoyltransferase and lipoate-protein ligase|g__Bacteroides	1.7543859649
+UniRef50_H6KZK2: Na(+)-translocating NADH-quinone reductase subunit F	1.7505530783
+UniRef50_H6KZK2: Na(+)-translocating NADH-quinone reductase subunit F|g__Bacteroides	1.7505530783
+UniRef50_Q650K7: Tyrosine--tRNA ligase	1.7497812773
+UniRef50_Q650K7: Tyrosine--tRNA ligase|g__Bacteroides	1.7497812774
+UniRef50_E1WW45	1.7452006981
+UniRef50_E1WW45|g__Bacteroides	1.7452006981
+UniRef50_Q89YL2	1.7452006981
+UniRef50_Q89YL2|g__Bacteroides	1.7452006981
+UniRef50_Q8A1W5	1.7452006981
+UniRef50_Q8A1W5|g__Bacteroides	1.7452006981
+UniRef50_E6SUV1: Two component transcriptional regulator, winged helix family	1.7361111111
+UniRef50_E6SUV1: Two component transcriptional regulator, winged helix family|g__Bacteroides	1.7361111111
+UniRef50_Q89ZD6: Cell surface protein	1.7361111111
+UniRef50_Q89ZD6: Cell surface protein|g__Bacteroides	1.7361111111
+UniRef50_R5W193	1.7339971679
+UniRef50_R5W193|g__Bacteroides	1.7339971679
+UniRef50_R6DZB6	1.7271157168
+UniRef50_R6DZB6|g__Bacteroides	1.7271157168
+UniRef50_B2RK67: UDP-glucose 6-dehydrogenase	1.7182130584
+UniRef50_B2RK67: UDP-glucose 6-dehydrogenase|g__Bacteroides	1.7182130584
+UniRef50_Q11QB8: 30S ribosomal protein S3	1.7182130584
+UniRef50_Q11QB8: 30S ribosomal protein S3|g__Bacteroides	1.7182130584
+UniRef50_I5ASD1: Nucleotide sugar dehydrogenase	1.7137960583
+UniRef50_I5ASD1: Nucleotide sugar dehydrogenase|g__Bacteroides	1.7137960583
+UniRef50_R6RWK6: Beta-galactosidase	1.7097613428
+UniRef50_R6RWK6: Beta-galactosidase|g__Bacteroides	1.7097613428999998
+UniRef50_R6SCN0	1.7094017094
+UniRef50_R6SCN0|g__Bacteroides	1.7094017094
+UniRef50_E1WRZ6	1.7050298380
+UniRef50_E1WRZ6|g__Bacteroides	1.705029838
+UniRef50_R6TIJ6: Signal recognition particle protein	1.7050298380
+UniRef50_R6TIJ6: Signal recognition particle protein|g__Bacteroides	1.705029838
+UniRef50_A5FGS7: Probable transcriptional regulatory protein Fjoh_2560	1.7006802721
+UniRef50_A5FGS7: Probable transcriptional regulatory protein Fjoh_2560|g__Bacteroides	1.7006802721
+UniRef50_F4KLR9: H+transporting two-sector ATPase alpha/beta subunit central region	1.7006802721
+UniRef50_F4KLR9: H+transporting two-sector ATPase alpha/beta subunit central region|g__Bacteroides	1.7006802721
+UniRef50_R6B8H9	1.7006802721
+UniRef50_R6B8H9|g__Bacteroides	1.7006802721
+UniRef50_R7NWG3	1.7006802721
+UniRef50_R7NWG3|g__Bacteroides	1.7006802721
+UniRef50_Q8A4L0: Type I restriction enzyme, M subunit	1.6920473773
+UniRef50_Q8A4L0: Type I restriction enzyme, M subunit|g__Bacteroides	1.6920473773
+UniRef50_P70882: Tetracycline resistance protein TetQ	1.6891891892
+UniRef50_P70882: Tetracycline resistance protein TetQ|g__Bacteroides	1.6891891892
+UniRef50_R5VD83	1.6870521769
+UniRef50_R5VD83|g__Bacteroides	1.6870521769
+UniRef50_B2RKJ1: NAD-specific glutamate dehydrogenase	1.6856326983
+UniRef50_B2RKJ1: NAD-specific glutamate dehydrogenase|g__Bacteroides	1.6856326983
+UniRef50_D3IEN1	1.6835016835
+UniRef50_D3IEN1|g__Bacteroides	1.6835016835
+UniRef50_R7E0R5: Polygalacturonase (Pectinase)	1.6835016835
+UniRef50_R7E0R5: Polygalacturonase (Pectinase)|g__Bacteroides	1.6835016835
+UniRef50_R6FFL5: Hydrogenase accessory protein HypB	1.6778523490
+UniRef50_R6FFL5: Hydrogenase accessory protein HypB|g__Bacteroides	1.677852349
+UniRef50_A6L0Q5	1.6750418760
+UniRef50_A6L0Q5|g__Bacteroides	1.675041876
+UniRef50_B0NU15: Polysaccharide biosynthesis protein	1.6750418760
+UniRef50_B0NU15: Polysaccharide biosynthesis protein|g__Bacteroides	1.675041876
+UniRef50_Q5HGK2: 3-oxoacyl-[acyl-carrier-protein] reductase FabG	1.6750418760
+UniRef50_Q5HGK2: 3-oxoacyl-[acyl-carrier-protein] reductase FabG|g__Bacteroides	1.675041876
+UniRef50_R5UGF8: PP-loop domain protein	1.6750418760
+UniRef50_R5UGF8: PP-loop domain protein|g__Bacteroides	1.675041876
+UniRef50_R7DML6: Biotin--[acetyl-CoA-carboxylase] ligase	1.6750418760
+UniRef50_R7DML6: Biotin--[acetyl-CoA-carboxylase] ligase|g__Bacteroides	1.675041876
+UniRef50_R6KCY7: Transporter major facilitator family protein	1.6708437761
+UniRef50_R6KCY7: Transporter major facilitator family protein|g__Bacteroides	1.6708437761
+UniRef50_B0NLL8	1.6666666667
+UniRef50_B0NLL8|g__Bacteroides	1.6666666667
+UniRef50_E1WWH6: Na(+)-translocating NADH-quinone reductase subunit A	1.6666666667
+UniRef50_E1WWH6: Na(+)-translocating NADH-quinone reductase subunit A|g__Bacteroides	1.6666666667
+UniRef50_F0R3R2	1.6666666667
+UniRef50_F0R3R2|g__Bacteroides	1.6666666667
+UniRef50_Q8A8Y1: Coagulation factor 5/8 type, C-terminal	1.6666666667
+UniRef50_Q8A8Y1: Coagulation factor 5/8 type, C-terminal|g__Bacteroides	1.6666666667
+UniRef50_R5J848	1.6666666667
+UniRef50_R5J848|g__Bacteroides	1.6666666667
+UniRef50_J9R6J8: Acetylornithine deacetylase/Succinyl-diaminopimelate desuccinylase-related deacylase	1.6543004628
+UniRef50_J9R6J8: Acetylornithine deacetylase/Succinyl-diaminopimelate desuccinylase-related deacylase|g__Bacteroides	1.6543004628
+UniRef50_R6K575	1.6542597188
+UniRef50_R6K575|g__Bacteroides	1.6542597188
+UniRef50_R6DIB1: Hydrolase NUDIX family	1.6501650165
+UniRef50_R6DIB1: Hydrolase NUDIX family|g__Bacteroides	1.6501650165
+UniRef50_L0G144	1.6481277757
+UniRef50_L0G144|g__Bacteroides	1.6481277758
+UniRef50_R6XGT6	1.6434218120
+UniRef50_R6XGT6|g__Bacteroides	1.643421812
+UniRef50_B5YGT5: 3-deoxy-manno-octulosonate cytidylyltransferase	1.6420361248
+UniRef50_B5YGT5: 3-deoxy-manno-octulosonate cytidylyltransferase|g__Bacteroides	1.6420361248
+UniRef50_Q64ZY8: Outer membrane protein oprM	1.6420361248
+UniRef50_Q64ZY8: Outer membrane protein oprM|g__Bacteroides	1.6420361248
+UniRef50_R5M8E0	1.6420361248
+UniRef50_R5M8E0|g__Bacteroides	1.6420361248
+UniRef50_R6RT73: Triosephosphate isomerase	1.6420361248
+UniRef50_R6RT73: Triosephosphate isomerase|g__Bacteroides	1.6420361248
+UniRef50_R6XM86: DNA repair protein radA	1.6420361248
+UniRef50_R6XM86: DNA repair protein radA|g__Bacteroides	1.6420361248
+UniRef50_W4PR50: DNA-directed RNA polymerase beta subunit	1.6380016380
+UniRef50_W4PR50: DNA-directed RNA polymerase beta subunit|g__Bacteroides	1.638001638
+UniRef50_Q11UF9: Peptidyl-prolyl cis-trans isomerase	1.6339869281
+UniRef50_Q11UF9: Peptidyl-prolyl cis-trans isomerase|g__Bacteroides	1.6339869281
+UniRef50_A8LC56: 50S ribosomal protein L3	1.6260162602
+UniRef50_A8LC56: 50S ribosomal protein L3|g__Bacteroides	1.6260162602
+UniRef50_C7N794: 2-oxoacid:ferredoxin oxidoreductase, beta subunit	1.6260162602
+UniRef50_C7N794: 2-oxoacid:ferredoxin oxidoreductase, beta subunit|g__Bacteroides	1.6260162602
+UniRef50_R6CKA3	1.6260162602
+UniRef50_R6CKA3|g__Bacteroides	1.6260162602
+UniRef50_R7PDU2: DNA ligase	1.6233766234
+UniRef50_R7PDU2: DNA ligase|g__Bacteroides	1.6233766234
+UniRef50_I0K5J6: Phosphomannomutase	1.6142050040
+UniRef50_I0K5J6: Phosphomannomutase|g__Bacteroides	1.614205004
+UniRef50_C9MMK5	1.6129032258
+UniRef50_C9MMK5|g__Bacteroides	1.6129032258
+UniRef50_R6M7Y6: Transketolase thiamine diphosphate binding domain protein	1.6129032258
+UniRef50_R6M7Y6: Transketolase thiamine diphosphate binding domain protein|g__Bacteroides	1.6129032258
+UniRef50_A7ALL4	1.6103059581
+UniRef50_A7ALL4|g__Bacteroides	1.6103059581
+UniRef50_B0NT38	1.6103059581
+UniRef50_B0NT38|g__Bacteroides	1.6103059581
+UniRef50_F0R1H7	1.6103059581
+UniRef50_F0R1H7|g__Bacteroides	1.6103059581
+UniRef50_R6L8N8: Arylsulfatase	1.6103059581
+UniRef50_R6L8N8: Arylsulfatase|g__Bacteroides	1.6103059581
+UniRef50_A5FFH5: Bacteroides conjugative transposon MobC/BfmC-like protein	1.6026949775
+UniRef50_A5FFH5: Bacteroides conjugative transposon MobC/BfmC-like protein|g__Bacteroides	1.6026949775
+UniRef50_B0NLB3	1.6025641026
+UniRef50_B0NLB3|g__Bacteroides	1.6025641026
+UniRef50_E6X4I7: Acetylglutamate kinase	1.6025641026
+UniRef50_E6X4I7: Acetylglutamate kinase|g__Bacteroides	1.6025641026
+UniRef50_F0R8Y7	1.6025641026
+UniRef50_F0R8Y7|g__Bacteroides	1.6025641026
+UniRef50_Q11QI8: Acetylglutamate kinase	1.6025641026
+UniRef50_Q11QI8: Acetylglutamate kinase|g__Bacteroides	1.6025641026
+UniRef50_R5AV72: MFS family major facilitator transporter glycerol-3-phosphate:cation symporter	1.6025641026
+UniRef50_R5AV72: MFS family major facilitator transporter glycerol-3-phosphate:cation symporter|g__Bacteroides	1.6025641026
+UniRef50_R5F938: Radical SAM domain protein	1.6025641026
+UniRef50_R5F938: Radical SAM domain protein|g__Bacteroides	1.6025641026
+UniRef50_R6ZV72	1.6025641026
+UniRef50_R6ZV72|g__Bacteroides	1.6025641026
+UniRef50_R5JTT9	1.5948963317
+UniRef50_R5JTT9|g__Bacteroides	1.5948963317
+UniRef50_R6DS19	1.5948963317
+UniRef50_R6DS19|g__Bacteroides	1.5948963317
+UniRef50_R7GYR7: Acyl-[acyl-carrier-protein]-UDP-N-acetylglucosami ne O-acyltransferase	1.5948963317
+UniRef50_R7GYR7: Acyl-[acyl-carrier-protein]-UDP-N-acetylglucosami ne O-acyltransferase|g__Bacteroides	1.5948963317
+UniRef50_B5F623: Uronate isomerase	1.5910898966
+UniRef50_B5F623: Uronate isomerase|g__Bacteroides	1.5910898966
+UniRef50_UPI000470128B: antitermination protein NusB	1.5797788310
+UniRef50_UPI000470128B: antitermination protein NusB|g__Bacteroides	1.579778831
+UniRef50_Q5LDR8	1.5649452269
+UniRef50_Q5LDR8|g__Bacteroides	1.5649452269
+UniRef50_R6LDX1: ADP-ribosylglycohydrolase	1.5649452269
+UniRef50_R6LDX1: ADP-ribosylglycohydrolase|g__Bacteroides	1.5649452269
+UniRef50_R6CUQ3: ABC transporter	1.5612802498
+UniRef50_R6CUQ3: ABC transporter|g__Bacteroides	1.5612802498
+UniRef50_Q8A4F0: ThiF family protein, ubiquitin-activating enzyme	1.5576323988
+UniRef50_Q8A4F0: ThiF family protein, ubiquitin-activating enzyme|g__Bacteroides	1.5576323988
+UniRef50_R6BPS6: Putrescine transport system permease potI	1.5576323988
+UniRef50_R6BPS6: Putrescine transport system permease potI|g__Bacteroides	1.5576323988
+UniRef50_Q7UID0: Thymidylate synthase	1.5503875969
+UniRef50_Q7UID0: Thymidylate synthase|g__Bacteroides	1.5503875969
+UniRef50_R6JDJ4: Transcription termination factor Rho	1.5475596821
+UniRef50_R6JDJ4: Transcription termination factor Rho|g__Bacteroides	1.5475596820000002
+UniRef50_B0NLK5	1.5432098765
+UniRef50_B0NLK5|g__Bacteroides	1.5432098765
+UniRef50_F4KXT8: Methionine aminopeptidase	1.5432098765
+UniRef50_F4KXT8: Methionine aminopeptidase|g__Bacteroides	1.5432098765
+UniRef50_Q8AAD8: Tryptophan synthase alpha chain	1.5432098765
+UniRef50_Q8AAD8: Tryptophan synthase alpha chain|g__Bacteroides	1.5432098765
+UniRef50_R7J3N7	1.5360983103
+UniRef50_R7J3N7|g__Bacteroides	1.5360983103
+UniRef50_A6L1N4: Ribosomal RNA small subunit methyltransferase A	1.5290519878
+UniRef50_A6L1N4: Ribosomal RNA small subunit methyltransferase A|g__Bacteroides	1.5290519878
+UniRef50_B6YS11: Diaminopimelate epimerase	1.5290519878
+UniRef50_B6YS11: Diaminopimelate epimerase|g__Bacteroides	1.5290519878
+UniRef50_F0R149: Beta-lactamase domain protein	1.5290519878
+UniRef50_F0R149: Beta-lactamase domain protein|g__Bacteroides	1.5290519878
+UniRef50_Q8A041: Acetyl xylan esterase A	1.5290519878
+UniRef50_Q8A041: Acetyl xylan esterase A|g__Bacteroides	1.5290519878
+UniRef50_Q8A1A3: Rhamnulokinase	1.5290519878
+UniRef50_Q8A1A3: Rhamnulokinase|g__Bacteroides	1.5290519878
+UniRef50_Q8A4L1	1.5290519878
+UniRef50_Q8A4L1|g__Bacteroides	1.5290519878
+UniRef50_Q8AAP9: Sulfate adenylyltransferase subunit 1	1.5290519878
+UniRef50_Q8AAP9: Sulfate adenylyltransferase subunit 1|g__Bacteroides	1.5290519878
+UniRef50_R5U735	1.5290519878
+UniRef50_R5U735|g__Bacteroides	1.5290519878
+UniRef50_R7KGK8	1.5263522800
+UniRef50_R7KGK8|g__Bacteroides	1.52635228
+UniRef50_R7KG97: Tetratricopeptide repeat family protein	1.5186028853
+UniRef50_R7KG97: Tetratricopeptide repeat family protein|g__Bacteroides	1.5186028853
+UniRef50_R7KRY3	1.5186028853
+UniRef50_R7KRY3|g__Bacteroides	1.5186028853
+UniRef50_E6SPF4: Sulfatase	1.5151515152
+UniRef50_E6SPF4: Sulfatase|g__Bacteroides	1.5151515152
+UniRef50_G8UMG2: ABC 3 transport family protein	1.5151515152
+UniRef50_G8UMG2: ABC 3 transport family protein|g__Bacteroides	1.5151515152
+UniRef50_Q8A1A0: Rhamnulose-1-phosphate aldolase	1.5151515152
+UniRef50_Q8A1A0: Rhamnulose-1-phosphate aldolase|g__Bacteroides	1.5151515152
+UniRef50_R6J682	1.5151515152
+UniRef50_R6J682|g__Bacteroides	1.5151515152
+UniRef50_R6LC65: Phospholipase patatin family	1.5151515152
+UniRef50_R6LC65: Phospholipase patatin family|g__Bacteroides	1.5151515152
+UniRef50_B2RIW6: Polyribonucleotide nucleotidyltransferase	1.5113839135
+UniRef50_B2RIW6: Polyribonucleotide nucleotidyltransferase|g__Bacteroides	1.5113839135
+UniRef50_Q64P75: TonB-like protein	1.5082956259
+UniRef50_Q64P75: TonB-like protein|g__Bacteroides	1.5082956259
+UniRef50_R5C323: Phosphate binding protein	1.5082956259
+UniRef50_R5C323: Phosphate binding protein|g__Bacteroides	1.5082956259
+UniRef50_Q11PK9: Cysteine--tRNA ligase	1.5048985637
+UniRef50_Q11PK9: Cysteine--tRNA ligase|g__Bacteroides	1.5048985637999999
+UniRef50_A2U077: Methylmalonyl-CoA mutase large subunit	1.5015015015
+UniRef50_A2U077: Methylmalonyl-CoA mutase large subunit|g__Bacteroides	1.5015015015
+UniRef50_Q8A869	1.5015015015
+UniRef50_Q8A869|g__Bacteroides	1.5015015015
+UniRef50_R5RH80: TPR-repeat-containing protein	1.4947683109
+UniRef50_R5RH80: TPR-repeat-containing protein|g__Bacteroides	1.4947683109
+UniRef50_A6LDN1: 2-isopropylmalate synthase	1.4914243102
+UniRef50_A6LDN1: 2-isopropylmalate synthase|g__Bacteroides	1.4914243102
+UniRef50_Q5LF90	1.4880952381
+UniRef50_Q5LF90|g__Bacteroides	1.4880952381
+UniRef50_B1ZNE5: 50S ribosomal protein L2	1.4814814815
+UniRef50_B1ZNE5: 50S ribosomal protein L2|g__Bacteroides	1.4814814815
+UniRef50_Q64VH8: ROK family transcriptional repressor	1.4814814815
+UniRef50_Q64VH8: ROK family transcriptional repressor|g__Bacteroides	1.4814814815
+UniRef50_R5EPQ9: Sec-independent protein translocase protein TatC	1.4814814815
+UniRef50_R5EPQ9: Sec-independent protein translocase protein TatC|g__Bacteroides	1.4814814815
+UniRef50_H1YF07: Endonuclease III	1.4792899408
+UniRef50_H1YF07: Endonuclease III|g__Bacteroides	1.4792899408
+UniRef50_Q2RZU6: tRNA nucleotidyltransferase/poly(A) polymerase family protein	1.4781966001
+UniRef50_Q2RZU6: tRNA nucleotidyltransferase/poly(A) polymerase family protein|g__Bacteroides	1.4781966001
+UniRef50_R5NVH9	1.4781966001
+UniRef50_R5NVH9|g__Bacteroides	1.4781966001
+UniRef50_R5JR48	1.4749262537
+UniRef50_R5JR48|g__Bacteroides	1.4749262537
+UniRef50_Q89ZU5	1.4619883041
+UniRef50_Q89ZU5|g__Bacteroides	1.4619883041
+UniRef50_R5DTE3	1.4619883041
+UniRef50_R5DTE3|g__Bacteroides	1.4619883041
+UniRef50_B2RL62: 30S ribosomal protein S2	1.4556040757
+UniRef50_B2RL62: 30S ribosomal protein S2|g__Bacteroides	1.4556040757
+UniRef50_R5UMU7	1.4556040757
+UniRef50_R5UMU7|g__Bacteroides	1.4556040757
+UniRef50_R7NTE3	1.4513788099
+UniRef50_R7NTE3|g__Bacteroides	1.4513788099
+UniRef50_L9LVN7: Transposase, mutator family	1.4492753623
+UniRef50_L9LVN7: Transposase, mutator family|g__Bacteroides	1.4492753623
+UniRef50_R6Z2A5	1.4492753623
+UniRef50_R6Z2A5|g__Bacteroides	1.4492753623
+UniRef50_R7ENW3	1.4492753623
+UniRef50_R7ENW3|g__Bacteroides	1.4492753623
+UniRef50_Q650K4: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase	1.4430014430
+UniRef50_Q650K4: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase|g__Bacteroides	1.443001443
+UniRef50_R7J997	1.4430014430
+UniRef50_R7J997|g__Bacteroides	1.443001443
+UniRef50_R5NUR5	1.4424902594
+UniRef50_R5NUR5|g__Bacteroides	1.4424902594
+UniRef50_Q09CP1: Mg-chelatase	1.4398848092
+UniRef50_Q09CP1: Mg-chelatase|g__Bacteroides	1.4398848092
+UniRef50_D6D2P8	1.4367816092
+UniRef50_D6D2P8|g__Bacteroides	1.4367816092
+UniRef50_I3YJ04	1.4367816092
+UniRef50_I3YJ04|g__Bacteroides	1.4367816092
+UniRef50_Q8A5L3: Transcriptional regulator	1.4367816092
+UniRef50_Q8A5L3: Transcriptional regulator|g__Bacteroides	1.4367816092
+UniRef50_R6ABW6	1.4367816092
+UniRef50_R6ABW6|g__Bacteroides	1.4367816092
+UniRef50_Q59219: Intracellular exo-alpha-L-arabinofuranosidase	1.4336917563
+UniRef50_Q59219: Intracellular exo-alpha-L-arabinofuranosidase|g__Bacteroides	1.4336917563
+UniRef50_B0NMQ8	1.4306151645
+UniRef50_B0NMQ8|g__Bacteroides	1.4306151645
+UniRef50_R5NU10: Prephenate dehydratase	1.4306151645
+UniRef50_R5NU10: Prephenate dehydratase|g__Bacteroides	1.4306151645
+UniRef50_R6S2C8	1.4306151645
+UniRef50_R6S2C8|g__Bacteroides	1.4306151645
+UniRef50_R6D8F5: Solute:sodium symporter (SSS) family transporter	1.4275517488
+UniRef50_R6D8F5: Solute:sodium symporter (SSS) family transporter|g__Bacteroides	1.4275517488
+UniRef50_A6L289: Conserved protein found in conjugate transposon	1.4245014245
+UniRef50_A6L289: Conserved protein found in conjugate transposon|g__Bacteroides	1.4245014245
+UniRef50_Q8A0Y5	1.4245014245
+UniRef50_Q8A0Y5|g__Bacteroides	1.4245014245
+UniRef50_R6CY54: TrkA C-terminal domain protein	1.4245014245
+UniRef50_R6CY54: TrkA C-terminal domain protein|g__Bacteroides	1.4245014245
+UniRef50_R6SYJ3	1.4245014245
+UniRef50_R6SYJ3|g__Bacteroides	1.4245014245
+UniRef50_A6KY75: Helicase, putative	1.4204545455
+UniRef50_A6KY75: Helicase, putative|g__Bacteroides	1.4204545455
+UniRef50_E6SN55: Abortive infection protein	1.4184397163
+UniRef50_E6SN55: Abortive infection protein|g__Bacteroides	1.4184397163
+UniRef50_I0KDE7: Undecaprenyl-diphosphatase	1.4184397163
+UniRef50_I0KDE7: Undecaprenyl-diphosphatase|g__Bacteroides	1.4184397163
+UniRef50_Q8A6E7	1.4154281670
+UniRef50_Q8A6E7|g__Bacteroides	1.415428167
+UniRef50_Q8A827: Glycoside transferase family 2	1.4124293785
+UniRef50_Q8A827: Glycoside transferase family 2|g__Bacteroides	1.4124293785
+UniRef50_R6LIV7: Transcriptional regulator effector binding domain protein	1.4124293785
+UniRef50_R6LIV7: Transcriptional regulator effector binding domain protein|g__Bacteroides	1.4124293785
+UniRef50_Q8AAD6: Indole-3-glycerol phosphate synthase	1.4064697609
+UniRef50_Q8AAD6: Indole-3-glycerol phosphate synthase|g__Bacteroides	1.4064697609
+UniRef50_R5SPN7: Sigma-70 family RNA polymerase sigma factor	1.4064697609
+UniRef50_R5SPN7: Sigma-70 family RNA polymerase sigma factor|g__Bacteroides	1.4064697609
+UniRef50_R6HWG1	1.4005602241
+UniRef50_R6HWG1|g__Bacteroides	1.4005602241
+UniRef50_R6W358	1.4005602241
+UniRef50_R6W358|g__Bacteroides	1.4005602241
+UniRef50_R6YU73: Dihydropteroate synthase	1.4005602241
+UniRef50_R6YU73: Dihydropteroate synthase|g__Bacteroides	1.4005602241
+UniRef50_A4T8K0: ATP synthase subunit alpha	1.3947001395
+UniRef50_A4T8K0: ATP synthase subunit alpha|g__Bacteroides	1.3947001395
+UniRef50_R5MP62	1.3888888889
+UniRef50_R5MP62|g__Bacteroides	1.3888888889
+UniRef50_R6W2X5	1.3888888889
+UniRef50_R6W2X5|g__Bacteroides	1.3888888889
+UniRef50_Q8AAG5	1.3831258645
+UniRef50_Q8AAG5|g__Bacteroides	1.3831258645
+UniRef50_R5C128	1.3831258645
+UniRef50_R5C128|g__Bacteroides	1.3831258645
+UniRef50_R6A8R0: HAD hydrolase family IA variant 1	1.3831258645
+UniRef50_R6A8R0: HAD hydrolase family IA variant 1|g__Bacteroides	1.3831258645
+UniRef50_R7H6J4: TonB-dependent receptor	1.3825261989
+UniRef50_R7H6J4: TonB-dependent receptor|g__Bacteroides	1.3825261989
+UniRef50_Q8A1F9: Regulatory protein SusR	1.3802622498
+UniRef50_Q8A1F9: Regulatory protein SusR|g__Bacteroides	1.3802622498
+UniRef50_C6IHH9	1.3774104683
+UniRef50_C6IHH9|g__Bacteroides	1.3774104683
+UniRef50_R6V5Y7	1.3774104683
+UniRef50_R6V5Y7|g__Bacteroides	1.3774104683
+UniRef50_A0M554: Bifunctional protein FolD	1.3661202186
+UniRef50_A0M554: Bifunctional protein FolD|g__Bacteroides	1.3661202186
+UniRef50_F0R285	1.3661202186
+UniRef50_F0R285|g__Bacteroides	1.3661202186
+UniRef50_F3ZRK2: Tyrosine recombinase XerC	1.3661202186
+UniRef50_F3ZRK2: Tyrosine recombinase XerC|g__Bacteroides	1.3661202186
+UniRef50_Q8A3P4: Transcriptional regulator	1.3661202186
+UniRef50_Q8A3P4: Transcriptional regulator|g__Bacteroides	1.3661202186
+UniRef50_R5M7G7: Capsular polysaccharide synthesis protein	1.3661202186
+UniRef50_R5M7G7: Capsular polysaccharide synthesis protein|g__Bacteroides	1.3661202186
+UniRef50_R6JN12: AP endonuclease family 2	1.3661202186
+UniRef50_R6JN12: AP endonuclease family 2|g__Bacteroides	1.3661202186
+UniRef50_B0NVB0	1.3550135501
+UniRef50_B0NVB0|g__Bacteroides	1.3550135501
+UniRef50_F5YJJ6: 2-oxoglutarate oxidoreductase, alpha subunit	1.3550135501
+UniRef50_F5YJJ6: 2-oxoglutarate oxidoreductase, alpha subunit|g__Bacteroides	1.3550135501
+UniRef50_P55253: Glucose-1-phosphate thymidylyltransferase	1.3550135501
+UniRef50_P55253: Glucose-1-phosphate thymidylyltransferase|g__Bacteroides	1.3550135501
+UniRef50_R5GBZ4: ABC transporter related protein	1.3550135501
+UniRef50_R5GBZ4: ABC transporter related protein|g__Bacteroides	1.3550135501
+UniRef50_R6W331: YD repeat (Two copies)	1.3495276653
+UniRef50_R6W331: YD repeat (Two copies)|g__Bacteroides	1.3495276653
+UniRef50_Q8L7B5: Chaperonin CPN60-like 1, mitochondrial	1.3440860215
+UniRef50_Q8L7B5: Chaperonin CPN60-like 1, mitochondrial|g__Bacteroides	1.3440860215
+UniRef50_Q8PYT3: Glycosyltransferase	1.3440860215
+UniRef50_Q8PYT3: Glycosyltransferase|g__Bacteroides	1.3440860215
+UniRef50_R6DZ01	1.3440860215
+UniRef50_R6DZ01|g__Bacteroides	1.3440860215
+UniRef50_I1YVX8: 1,4-dihydroxy-2-naphthoate octaprenyltransferase	1.3386880857
+UniRef50_I1YVX8: 1,4-dihydroxy-2-naphthoate octaprenyltransferase|g__Bacteroides	1.3386880857
+UniRef50_R6MPT3: LysR substrate binding domain protein	1.3386880857
+UniRef50_R6MPT3: LysR substrate binding domain protein|g__Bacteroides	1.3386880857
+UniRef50_R6V9G1	1.3386880857
+UniRef50_R6V9G1|g__Bacteroides	1.3386880857
+UniRef50_R5KU76	1.3333333333
+UniRef50_R5KU76|g__Bacteroides	1.3333333333
+UniRef50_R5TXC7	1.3333333333
+UniRef50_R5TXC7|g__Bacteroides	1.3333333333
+UniRef50_R6T2Y9: Transcriptional regulator	1.3333333333
+UniRef50_R6T2Y9: Transcriptional regulator|g__Bacteroides	1.3333333333
+UniRef50_B6EJ93: Imidazole glycerol phosphate synthase subunit HisF	1.3280212483
+UniRef50_B6EJ93: Imidazole glycerol phosphate synthase subunit HisF|g__Bacteroides	1.3280212483
+UniRef50_R7CXK0: Deoxyribose-phosphate aldolase	1.3280212483
+UniRef50_R7CXK0: Deoxyribose-phosphate aldolase|g__Bacteroides	1.3280212483
+UniRef50_Q8A269	1.3227513228
+UniRef50_Q8A269|g__Bacteroides	1.3227513228
+UniRef50_R5MRY4: Transposase IS4 family	1.3227513228
+UniRef50_R5MRY4: Transposase IS4 family|g__Bacteroides	1.3227513228
+UniRef50_R6JF08	1.3214416680
+UniRef50_R6JF08|g__Bacteroides	1.321441668
+UniRef50_Q64TC3	1.3201320132
+UniRef50_Q64TC3|g__Bacteroides	1.3201320132
+UniRef50_D6D339: His Kinase A (Phosphoacceptor) domain./Histidine kinase-, DNA gyrase B-, and HSP90-like ATPase./Response regulator receiver domain	1.3192612137
+UniRef50_D6D339: His Kinase A (Phosphoacceptor) domain	1.3192612137
+UniRef50_R6B7M5: SusD family protein	1.3175230567
+UniRef50_R6B7M5: SusD family protein|g__Bacteroides	1.3175230567
+UniRef50_R6HK33	1.3175230567
+UniRef50_R6HK33|g__Bacteroides	1.3175230567
+UniRef50_B0TGQ8: Dihydroorotate dehydrogenase B (NAD(+)), catalytic subunit	1.3123359580
+UniRef50_B0TGQ8: Dihydroorotate dehydrogenase B (NAD(+)), catalytic subunit|g__Bacteroides	1.312335958
+UniRef50_D5EWR9	1.3123359580
+UniRef50_D5EWR9|g__Bacteroides	1.312335958
+UniRef50_R5K3A3	1.3123359580
+UniRef50_R5K3A3|g__Bacteroides	1.312335958
+UniRef50_R6ASV6	1.3071895425
+UniRef50_R6ASV6|g__Bacteroides	1.3071895425
+UniRef50_R6JIL8	1.3071895425
+UniRef50_R6JIL8|g__Bacteroides	1.3071895425
+UniRef50_R7D0M9	1.3071895425
+UniRef50_R7D0M9|g__Bacteroides	1.3071895425
+UniRef50_A3QG19: Homoserine O-succinyltransferase	1.3020833333
+UniRef50_A3QG19: Homoserine O-succinyltransferase|g__Bacteroides	1.3020833333
+UniRef50_R6SK49	1.3020833333
+UniRef50_R6SK49|g__Bacteroides	1.3020833333
+UniRef50_R6V714: Transmembrane permease	1.3020833333
+UniRef50_R6V714: Transmembrane permease|g__Bacteroides	1.3020833333
+UniRef50_R7KTF4	1.3020833333
+UniRef50_R7KTF4|g__Bacteroides	1.3020833333
+UniRef50_R9I2L5	1.3020833333
+UniRef50_R9I2L5|g__Bacteroides	1.3020833333
+UniRef50_R7CYA6	1.2970168612
+UniRef50_R7CYA6|g__Bacteroides	1.2970168612
+UniRef50_R7DFS4	1.2970168612
+UniRef50_R7DFS4|g__Bacteroides	1.2970168612
+UniRef50_R7EJ51	1.2970168612
+UniRef50_R7EJ51|g__Bacteroides	1.2970168612
+UniRef50_W4PDX5: Immunoreactive 53 kDa antigen PG123	1.2970168612
+UniRef50_W4PDX5: Immunoreactive 53 kDa antigen PG123|g__Bacteroides	1.2970168612
+UniRef50_Q8AAE0: Outer membrane protein	1.2970168612
+UniRef50_Q8AAE0: Outer membrane protein|g__Bacteroides	1.2970168612
+UniRef50_R6JM25	1.2919896641
+UniRef50_R6JM25|g__Bacteroides	1.2919896641
+UniRef50_R7LCZ8: YitT family protein	1.2870012870
+UniRef50_R7LCZ8: YitT family protein|g__Bacteroides	1.287001287
+UniRef50_A6H086: Potassium-transporting ATPase A chain	1.2845215157
+UniRef50_A6H086: Potassium-transporting ATPase A chain|g__Bacteroides	1.2845215157
+UniRef50_D3ICU3	1.2845215157
+UniRef50_D3ICU3|g__Bacteroides	1.2845215157
+UniRef50_B0NME1	1.2820512821
+UniRef50_B0NME1|g__Bacteroides	1.2820512821
+UniRef50_R7NZJ6	1.2820512821
+UniRef50_R7NZJ6|g__Bacteroides	1.2820512821
+UniRef50_R6EBA6	1.2771392082
+UniRef50_R6EBA6|g__Bacteroides	1.2771392082
+UniRef50_D7J4L8: Glycosyl transferase, family 8	1.2722646310
+UniRef50_D7J4L8: Glycosyl transferase, family 8|g__Bacteroides	1.272264631
+UniRef50_R5MD26: Sigma factor regulatory protein FecR/PupR family	1.2722646310
+UniRef50_R5MD26: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides	1.272264631
+UniRef50_R5UTD2: Riboflavin biosynthesis protein RibF	1.2722646310
+UniRef50_R5UTD2: Riboflavin biosynthesis protein RibF|g__Bacteroides	1.272264631
+UniRef50_R6ABT7: Sigma factor regulatory protein FecR/PupR family	1.2722646310
+UniRef50_R6ABT7: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides	1.272264631
+UniRef50_Q5L8Z8: Malate dehydrogenase	1.2626262626
+UniRef50_Q5L8Z8: Malate dehydrogenase|g__Bacteroides	1.2626262626
+UniRef50_Q8A9S3: Aspartate carbamoyltransferase	1.2626262626
+UniRef50_Q8A9S3: Aspartate carbamoyltransferase|g__Bacteroides	1.2626262626
+UniRef50_Q8AAJ1: Glycoside transferase family 2	1.2626262626
+UniRef50_Q8AAJ1: Glycoside transferase family 2|g__Bacteroides	1.2626262626
+UniRef50_E1WVW3	1.2594458438
+UniRef50_E1WVW3|g__Bacteroides	1.2594458438
+UniRef50_R6DGF7	1.2578616352
+UniRef50_R6DGF7|g__Bacteroides	1.2578616352
+UniRef50_R6D3Z1	1.2554972337
+UniRef50_R6D3Z1|g__Bacteroides	1.2554972337
+UniRef50_Q8A9W0	1.2531328321
+UniRef50_Q8A9W0|g__Bacteroides	1.2531328321
+UniRef50_R6JA28	1.2531328321
+UniRef50_R6JA28|g__Bacteroides	1.2531328321
+UniRef50_F2KVV0: DNA gyrase/topoisomerase IV, A subunit	1.2484394507
+UniRef50_F2KVV0: DNA gyrase/topoisomerase IV, A subunit|g__Bacteroides	1.2484394507
+UniRef50_Q8AB21: Integrase	1.2484394507
+UniRef50_Q8AB21: Integrase|g__Bacteroides	1.2484394507
+UniRef50_R6JJ68	1.2484394507
+UniRef50_R6JJ68|g__Bacteroides	1.2484394507
+UniRef50_R6RPC2: Transcriptional regulator	1.2484394507
+UniRef50_R6RPC2: Transcriptional regulator|g__Bacteroides	1.2484394507
+UniRef50_R6YFA8	1.2484394507
+UniRef50_R6YFA8|g__Bacteroides	1.2484394507
+UniRef50_D5EH68: NAD-dependent epimerase/dehydratase	1.2391573730
+UniRef50_D5EH68: NAD-dependent epimerase/dehydratase|g__Bacteroides	1.239157373
+UniRef50_Q8A0B5: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase 2	1.2391573730
+UniRef50_Q8A0B5: 4-deoxy-L-threo-5-hexosulose-uronate ketol-isomerase 2|g__Bacteroides	1.239157373
+UniRef50_Q8A1E9: N-acetylornithine carbamoyltransferase	1.2391573730
+UniRef50_Q8A1E9: N-acetylornithine carbamoyltransferase|g__Bacteroides	1.239157373
+UniRef50_R6RWC3: Phosphatidate cytidylyltransferase	1.2391573730
+UniRef50_R6RWC3: Phosphatidate cytidylyltransferase|g__Bacteroides	1.239157373
+UniRef50_R7PC42	1.2391573730
+UniRef50_R7PC42|g__Bacteroides	1.239157373
+UniRef50_R5FP64: DNA gyrase subunit A	1.2360939431
+UniRef50_R5FP64: DNA gyrase subunit A|g__Bacteroides	1.2360939431
+UniRef50_R6B3N2: ATPase AAA family	1.2345679012
+UniRef50_R6B3N2: ATPase AAA family|g__Bacteroides	1.2345679012
+UniRef50_R6XVK0: Signal recognition particle receptor FtsY	1.2345679012
+UniRef50_R6XVK0: Signal recognition particle receptor FtsY|g__Bacteroides	1.2345679012
+UniRef50_R7KZF1	1.2345679012
+UniRef50_R7KZF1|g__Bacteroides	1.2345679012
+UniRef50_R5I2X5: Phage RecT family recombinase	1.2300123001
+UniRef50_R5I2X5: Phage RecT family recombinase|g__Bacteroides	1.2300123001
+UniRef50_Q9JS61: Dihydroxy-acid dehydratase	1.2268512248
+UniRef50_Q9JS61: Dihydroxy-acid dehydratase|g__Bacteroides	1.2268512249
+UniRef50_A6L0Q1	1.2210012210
+UniRef50_A6L0Q1|g__Bacteroides	1.221001221
+UniRef50_Q5LHZ1: N-acetyl-gamma-glutamyl-phosphate reductase	1.2210012210
+UniRef50_Q5LHZ1: N-acetyl-gamma-glutamyl-phosphate reductase|g__Bacteroides	1.221001221
+UniRef50_Q8A5U0: Glycoside transferase family 4	1.2165450122
+UniRef50_Q8A5U0: Glycoside transferase family 4|g__Bacteroides	1.2165450122
+UniRef50_Q8ABR0: Glycoside transferase family 2	1.2165450122
+UniRef50_Q8ABR0: Glycoside transferase family 2|g__Bacteroides	1.2165450122
+UniRef50_R5BYQ9: Mannose-6-phosphate isomerase class I	1.2165450122
+UniRef50_R5BYQ9: Mannose-6-phosphate isomerase class I|g__Bacteroides	1.2165450122
+UniRef50_R6SE59	1.2143290832
+UniRef50_R6SE59|g__Bacteroides	1.2143290832
+UniRef50_W4US16: Alanine--tRNA ligase	1.2135922330
+UniRef50_W4US16: Alanine--tRNA ligase|g__Bacteroides	1.213592233
+UniRef50_E4T664: Polyprenyl synthetase	1.2121212121
+UniRef50_E4T664: Polyprenyl synthetase|g__Bacteroides	1.2121212121
+UniRef50_L7WG82: ATPase, AAA_3 family	1.2121212121
+UniRef50_L7WG82: ATPase, AAA_3 family|g__Bacteroides	1.2121212121
+UniRef50_Q7MWA2: D-alanine--D-alanine ligase	1.2121212121
+UniRef50_Q7MWA2: D-alanine--D-alanine ligase|g__Bacteroides	1.2121212121
+UniRef50_R6ABJ5: Cobalamin biosynthesis protein CobD	1.2121212121
+UniRef50_R6ABJ5: Cobalamin biosynthesis protein CobD|g__Bacteroides	1.2121212121
+UniRef50_R6JBQ5	1.2121212121
+UniRef50_R6JBQ5|g__Bacteroides	1.2121212121
+UniRef50_R6U2U2: Mannose-6-phosphate isomerase type 1	1.2121212121
+UniRef50_R6U2U2: Mannose-6-phosphate isomerase type 1|g__Bacteroides	1.2121212121
+UniRef50_R7KQZ5: Surface layer protein	1.2121212121
+UniRef50_R7KQZ5: Surface layer protein|g__Bacteroides	1.2121212121
+UniRef50_R6AB99	1.2077294686
+UniRef50_R6AB99|g__Bacteroides	1.2077294686
+UniRef50_R6EIX3	1.2077294686
+UniRef50_R6EIX3|g__Bacteroides	1.2077294686
+UniRef50_S3Y6P5	1.2077294686
+UniRef50_S3Y6P5|g__Bacteroides	1.2077294686
+UniRef50_Q89ZM4: Valine--tRNA ligase	1.2048192771
+UniRef50_Q89ZM4: Valine--tRNA ligase|g__Bacteroides	1.2048192771
+UniRef50_Q8A624: ATP-dependent 6-phosphofructokinase 2	1.2033694344
+UniRef50_Q8A624: ATP-dependent 6-phosphofructokinase 2|g__Bacteroides	1.2033694344
+UniRef50_A6L2H0: Glycoside hydrolase family 2, candidate beta-glycosidase	1.2012012012
+UniRef50_A6L2H0: Glycoside hydrolase family 2, candidate beta-glycosidase|g__Bacteroides	1.2012012012
+UniRef50_R5IKU0: UDP-N-acetylenolpyruvoylglucosamine reductase	1.1990407674
+UniRef50_R5IKU0: UDP-N-acetylenolpyruvoylglucosamine reductase|g__Bacteroides	1.1990407674
+UniRef50_R6JN09: Sigma factor regulatory protein FecR/PupR family	1.1990407674
+UniRef50_R6JN09: Sigma factor regulatory protein FecR/PupR family|g__Bacteroides	1.1990407674
+UniRef50_W0EUZ5: Membrane protein	1.1990407674
+UniRef50_W0EUZ5: Membrane protein|g__Bacteroides	1.1990407674
+UniRef50_R5NT69	1.1947431302
+UniRef50_R5NT69|g__Bacteroides	1.1947431302
+UniRef50_R6F307: Auxiliary transport protein membrane fusion protein (MFP) family protein	1.1947431302
+UniRef50_R6F307: Auxiliary transport protein membrane fusion protein (MFP) family protein|g__Bacteroides	1.1947431302
+UniRef50_G8TJF7: Transposase IS204/IS1001/IS1096/IS1165 family protein	1.1933174224
+UniRef50_G8TJF7: Transposase IS204/IS1001/IS1096/IS1165 family protein|g__Bacteroides	1.1933174224
+UniRef50_D6CYP9: Beta-xylosidase	1.1904761905
+UniRef50_D6CYP9: Beta-xylosidase|g__Bacteroides	1.1904761905
+UniRef50_R5JP39: PfkB family carbohydrate kinase	1.1904761905
+UniRef50_R5JP39: PfkB family carbohydrate kinase|g__Bacteroides	1.1904761905
+UniRef50_A6LEG5: DNA-directed RNA polymerase subunit alpha	1.1862396204
+UniRef50_A6LEG5: DNA-directed RNA polymerase subunit alpha|g__Bacteroides	1.1862396204
+UniRef50_Q043T3: Integrase	1.1862396204
+UniRef50_Q043T3: Integrase|g__Bacteroides	1.1862396204
+UniRef50_Q8A4G5: Putative integrase/recombinase	1.1862396204
+UniRef50_Q8A4G5: Putative integrase/recombinase|g__Bacteroides	1.1862396204
+UniRef50_R6YSY2	1.1862396204
+UniRef50_R6YSY2|g__Bacteroides	1.1862396204
+UniRef50_J0S1M2: ATPase associated with various cellular activities AAA_3	1.1820330969
+UniRef50_J0S1M2: ATPase associated with various cellular activities AAA_3|g__Bacteroides	1.1820330969
+UniRef50_K6BKY7	1.1820330969
+UniRef50_K6BKY7|g__Bacteroides	1.1820330969
+UniRef50_R5V0C7: Peptidase M28 family	1.1820330969
+UniRef50_R5V0C7: Peptidase M28 family|g__Bacteroides	1.1820330969
+UniRef50_F0P1A4: Nicotinate-nucleotide pyrophosphorylase	1.1778563015
+UniRef50_F0P1A4: Nicotinate-nucleotide pyrophosphorylase|g__Bacteroides	1.1778563015
+UniRef50_F9D2R9: Pyruvate synthase	1.1778563015
+UniRef50_F9D2R9: Pyruvate synthase|g__Bacteroides	1.1778563015
+UniRef50_Q5LC41: Membrane protein insertase YidC	1.1747512322
+UniRef50_Q5LC41: Membrane protein insertase YidC|g__Bacteroides	1.1747512322
+UniRef50_Q7UQD2: UPF0365 protein RB6389	1.1737089202
+UniRef50_Q7UQD2: UPF0365 protein RB6389|g__Bacteroides	1.1737089202
+UniRef50_C6W2Y1: Oxidoreductase domain protein	1.1695906433
+UniRef50_C6W2Y1: Oxidoreductase domain protein|g__Bacteroides	1.1695906433
+UniRef50_R5JDR7	1.1695906433
+UniRef50_R5JDR7|g__Bacteroides	1.1695906433
+UniRef50_R6L6N2	1.1695906433
+UniRef50_R6L6N2|g__Bacteroides	1.1695906433
+UniRef50_R7KTX1	1.1668611435
+UniRef50_R7KTX1|g__Bacteroides	1.1668611435
+UniRef50_A6L8M1	1.1655011655
+UniRef50_A6L8M1|g__Bacteroides	1.1655011655
+UniRef50_O83668: Fructose-bisphosphate aldolase	1.1614401858
+UniRef50_O83668: Fructose-bisphosphate aldolase|g__Bacteroides	1.1614401858
+UniRef50_R5JNN6	1.1614401858
+UniRef50_R5JNN6|g__Bacteroides	1.1614401858
+UniRef50_A6KYD5: Aldose 1-epimerase	1.1574074074
+UniRef50_A6KYD5: Aldose 1-epimerase|g__Bacteroides	1.1574074074
+UniRef50_F3ZPR6: Endonuclease/exonuclease/phosphatase	1.1574074074
+UniRef50_F3ZPR6: Endonuclease/exonuclease/phosphatase|g__Bacteroides	1.1574074074
+UniRef50_P71103: Phosphate acetyltransferase	1.1534025375
+UniRef50_P71103: Phosphate acetyltransferase|g__Bacteroides	1.1534025375
+UniRef50_F4KN33: Branched-chain amino acid aminotransferase	1.1494252874
+UniRef50_F4KN33: Branched-chain amino acid aminotransferase|g__Bacteroides	1.1494252874
+UniRef50_F9D1I7	1.1494252874
+UniRef50_F9D1I7|g__Bacteroides	1.1494252874
+UniRef50_R7KHJ8	1.1494252874
+UniRef50_R7KHJ8|g__Bacteroides	1.1494252874
+UniRef50_A6L012: Biosynthetic arginine decarboxylase	1.1474469306
+UniRef50_A6L012: Biosynthetic arginine decarboxylase|g__Bacteroides	1.1474469306
+UniRef50_Q64X44: Thiamine biosynthesis lipoprotein ApbE	1.1454753723
+UniRef50_Q64X44: Thiamine biosynthesis lipoprotein ApbE|g__Bacteroides	1.1454753723
+UniRef50_Q89YI4	1.1454753723
+UniRef50_Q89YI4|g__Bacteroides	1.1454753723
+UniRef50_R6ALI4	1.1454753723
+UniRef50_R6ALI4|g__Bacteroides	1.1454753723
+UniRef50_R6FQM9	1.1454753723
+UniRef50_R6FQM9|g__Bacteroides	1.1454753723
+UniRef50_R6AGI9: Efflux transporter RND family MFP subunit	1.1376564278
+UniRef50_R6AGI9: Efflux transporter RND family MFP subunit|g__Bacteroides	1.1376564278
+UniRef50_R6JI28: Auxiliary transport protein membrane fusion protein (MFP) family protein	1.1376564278
+UniRef50_R6JI28: Auxiliary transport protein membrane fusion protein (MFP) family protein|g__Bacteroides	1.1376564278
+UniRef50_R6EYN4: Heptosyltransferase	1.1337868481
+UniRef50_R6EYN4: Heptosyltransferase|g__Bacteroides	1.1337868481
+UniRef50_R6J7D8	1.1337868481
+UniRef50_R6J7D8|g__Bacteroides	1.1337868481
+UniRef50_Q8I0H7: Heat shock 70 kDa protein, mitochondrial	1.1309027078
+UniRef50_Q8I0H7: Heat shock 70 kDa protein, mitochondrial|g__Bacteroides	1.1309027078
+UniRef50_Q6LMU2: Protein RecA	1.1299435028
+UniRef50_Q6LMU2: Protein RecA|g__Bacteroides	1.1299435028
+UniRef50_R6SBV4	1.1299435028
+UniRef50_R6SBV4|g__Bacteroides	1.1299435028
+UniRef50_D6DM26: Iron-only hydrogenase maturation protein HydE	1.1261261261
+UniRef50_D6DM26: Iron-only hydrogenase maturation protein HydE|g__Bacteroides	1.1261261261
+UniRef50_C6XV67: Glycosidase PH1107-related	1.1185682327
+UniRef50_C6XV67: Glycosidase PH1107-related|g__Bacteroides	1.1185682327
+UniRef50_R6AKT0	1.1185682327
+UniRef50_R6AKT0|g__Bacteroides	1.1185682327
+UniRef50_R6CEQ7: A/G-specific adenine glycosylase	1.1148272018
+UniRef50_R6CEQ7: A/G-specific adenine glycosylase|g__Bacteroides	1.1148272018
+UniRef50_Q650E6: TraA	1.1111111111
+UniRef50_Q650E6: TraA|g__Bacteroides	1.1111111111
+UniRef50_Q8A1H6: Beta-glucanase	1.1111111111
+UniRef50_Q8A1H6: Beta-glucanase|g__Bacteroides	1.1111111111
+UniRef50_Q8A2E4: Erythronate-4-phosphate dehydrogenase	1.1111111111
+UniRef50_Q8A2E4: Erythronate-4-phosphate dehydrogenase|g__Bacteroides	1.1111111111
+UniRef50_Q8A345	1.1098779134
+UniRef50_Q8A345|g__Bacteroides	1.1098779134
+UniRef50_A0A024GWJ3: Uridine diphosphate galacturonate 4-epimerase	1.1074197121
+UniRef50_A0A024GWJ3: Uridine diphosphate galacturonate 4-epimerase|g__Bacteroides	1.1074197121
+UniRef50_S3YBR0	1.1074197121
+UniRef50_S3YBR0|g__Bacteroides	1.1074197121
+UniRef50_D7J4M8: Transcriptional regulatory protein	1.1037527594
+UniRef50_D7J4M8: Transcriptional regulatory protein|g__Bacteroides	1.1037527594
+UniRef50_R7NTA9	1.1037527594
+UniRef50_R7NTA9|g__Bacteroides	1.1037527594
+UniRef50_A7IH78: Choloylglycine hydrolase	1.1001100110
+UniRef50_A7IH78: Choloylglycine hydrolase|g__Bacteroides	1.100110011
+UniRef50_B6YR69: S-adenosylmethionine:tRNA ribosyltransferase-isomerase	1.1001100110
+UniRef50_B6YR69: S-adenosylmethionine:tRNA ribosyltransferase-isomerase|g__Bacteroides	1.100110011
+UniRef50_G8UNW9: Efflux transporter, RND family, MFP subunit	1.0964912281
+UniRef50_G8UNW9: Efflux transporter, RND family, MFP subunit|g__Bacteroides	1.0964912281
+UniRef50_Q8A2R1	1.0928961749
+UniRef50_Q8A2R1|g__Bacteroides	1.0928961749
+UniRef50_B2RID6: Phosphoserine aminotransferase	1.0893246187
+UniRef50_B2RID6: Phosphoserine aminotransferase|g__Bacteroides	1.0893246187
+UniRef50_F9D3S7: M20A family peptidase	1.0893246187
+UniRef50_F9D3S7: M20A family peptidase|g__Bacteroides	1.0893246187
+UniRef50_R6ZR61: Efflux transporter RND family MFP subunit	1.0893246187
+UniRef50_R6ZR61: Efflux transporter RND family MFP subunit|g__Bacteroides	1.0893246187
+UniRef50_R5C5X4	1.0875504744
+UniRef50_R5C5X4|g__Bacteroides	1.0875504744
+UniRef50_H0UKG1: Urocanate hydratase	1.0857763301
+UniRef50_H0UKG1: Urocanate hydratase|g__Bacteroides	1.0857763301
+UniRef50_Q8A898: Component of multidrug efflux system	1.0857763301
+UniRef50_Q8A898: Component of multidrug efflux system|g__Bacteroides	1.0857763301
+UniRef50_Q8ABV0	1.0822510823
+UniRef50_Q8ABV0|g__Bacteroides	1.0822510823
+UniRef50_R5C915	1.0822510823
+UniRef50_R5C915|g__Bacteroides	1.0822510823
+UniRef50_R6AFI7: Kinase PfkB family	1.0822510823
+UniRef50_R6AFI7: Kinase PfkB family|g__Bacteroides	1.0822510823
+UniRef50_A3PAU4: Chorismate synthase	1.0787486516
+UniRef50_A3PAU4: Chorismate synthase|g__Bacteroides	1.0787486516
+UniRef50_R6MAF9	1.0787486516
+UniRef50_R6MAF9|g__Bacteroides	1.0787486516
+UniRef50_Q8A4R5: SusD homolog	1.0780351002
+UniRef50_Q8A4R5: SusD homolog|g__Bacteroides	1.0780351002
+UniRef50_R6ALH7: TonB-linked outer membrane protein SusC/RagA family	1.0775862069
+UniRef50_R6ALH7: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides	1.0775862069
+UniRef50_F0SDG2: Glycosyl hydrolase family 88	1.0718113612
+UniRef50_F0SDG2: Glycosyl hydrolase family 88|g__Bacteroides	1.0718113612
+UniRef50_Q8A2E8: Ribonuclease 3	1.0649627263
+UniRef50_Q8A2E8: Ribonuclease 3|g__Bacteroides	1.0649627263
+UniRef50_Q8A6Q6: Pyruvate dehydrogenase	1.0649627263
+UniRef50_Q8A6Q6: Pyruvate dehydrogenase|g__Bacteroides	1.0649627263
+UniRef50_R5ALN9: Conjugative transposon protein TraG	1.0649627263
+UniRef50_R5ALN9: Conjugative transposon protein TraG|g__Bacteroides	1.0649627263
+UniRef50_R6ETZ6: Pyruvate phosphate dikinase PEP/pyruvate binding domain protein	1.0642082362
+UniRef50_R6ETZ6: Pyruvate phosphate dikinase PEP/pyruvate binding domain protein|g__Bacteroides	1.0642082362999998
+UniRef50_R7F5F2: Integrase family protein	1.0615711253
+UniRef50_R7F5F2: Integrase family protein|g__Bacteroides	1.0615711253
+UniRef50_A0A016FAQ7: N-6 DNA Methylase family protein (Fragment)	1.0583263888
+UniRef50_A0A016FAQ7: N-6 DNA Methylase family protein (Fragment)|g__Bacteroides	1.0583263888
+UniRef50_A6L242: Transposase	1.0582010582
+UniRef50_A6L242: Transposase|g__Bacteroides	1.0582010582
+UniRef50_B3CBX4: Dinuclear metal center protein, YbgI family	1.0582010582
+UniRef50_B3CBX4: Dinuclear metal center protein, YbgI family|g__Bacteroides	1.0582010582
+UniRef50_Q89ZK3: 4-hydroxythreonine-4-phosphate dehydrogenase	1.0582010582
+UniRef50_Q89ZK3: 4-hydroxythreonine-4-phosphate dehydrogenase|g__Bacteroides	1.0582010582
+UniRef50_Q8AAS0: Capsular polysaccharide biosynthesis glycosyltransferase	1.0582010582
+UniRef50_Q8AAS0: Capsular polysaccharide biosynthesis glycosyltransferase|g__Bacteroides	1.0582010582
+UniRef50_Q89ZF7	1.0548523207
+UniRef50_Q89ZF7|g__Bacteroides	1.0548523207
+UniRef50_R5CHL6	1.0548523207
+UniRef50_R5CHL6|g__Bacteroides	1.0548523207
+UniRef50_R7DK98: ATP-binding protein Mrp/Nbp35 family	1.0548523207
+UniRef50_R7DK98: ATP-binding protein Mrp/Nbp35 family|g__Bacteroides	1.0548523207
+UniRef50_R5F658: Alpha-glucosidase II	1.0515247108
+UniRef50_R5F658: Alpha-glucosidase II|g__Bacteroides	1.0515247108
+UniRef50_R7D1E2: Thioredoxin family protein	1.0515247108
+UniRef50_R7D1E2: Thioredoxin family protein|g__Bacteroides	1.0515247108
+UniRef50_Q8A2J5: SusC homolog	1.0504201681
+UniRef50_Q8A2J5: SusC homolog|g__Bacteroides	1.0504201681
+UniRef50_Q8A2A1: Translation initiation factor IF-2	1.0486112908
+UniRef50_Q8A2A1: Translation initiation factor IF-2|g__Bacteroides	1.0486112908
+UniRef50_S3ZKH9	1.0482180294
+UniRef50_S3ZKH9|g__Bacteroides	1.0482180294
+UniRef50_R5JS40	1.0465724751
+UniRef50_R5JS40|g__Bacteroides	1.0465724751
+UniRef50_A6L0K3: Undecaprenyl-phosphate alpha-N-acetylglucosaminyltransferase	1.0449320794
+UniRef50_A6L0K3: Undecaprenyl-phosphate alpha-N-acetylglucosaminyltransferase|g__Bacteroides	1.0449320794
+UniRef50_R5RER3: Six-hairpin glycosidase	1.0449320794
+UniRef50_R5RER3: Six-hairpin glycosidase|g__Bacteroides	1.0449320794
+UniRef50_R6S6T5: TPR-domain containing protein	1.0431278273
+UniRef50_R6S6T5: TPR-domain containing protein|g__Bacteroides	1.0431278274
+UniRef50_G8UI78	1.0416666667
+UniRef50_G8UI78|g__Bacteroides	1.0416666667
+UniRef50_R5UMK2	1.0416666667
+UniRef50_R5UMK2|g__Bacteroides	1.0416666667
+UniRef50_R5K747: Response regulator receiver domain-containing protein	1.0408534999
+UniRef50_R5K747: Response regulator receiver domain-containing protein|g__Bacteroides	1.0408534999
+UniRef50_R5JDJ3	1.0400416017
+UniRef50_R5JDJ3|g__Bacteroides	1.0400416017
+UniRef50_Q64YW0: Beta-N-acetylglucosaminidase	1.0395010395
+UniRef50_Q64YW0: Beta-N-acetylglucosaminidase|g__Bacteroides	1.0395010395
+UniRef50_Q8A715	1.0384215992
+UniRef50_Q8A715|g__Bacteroides	1.0384215992
+UniRef50_R7NV35: Thiol:disulfide interchange protein	1.0384215992
+UniRef50_R7NV35: Thiol:disulfide interchange protein|g__Bacteroides	1.0384215992
+UniRef50_R5EYM2	1.0368066356
+UniRef50_R5EYM2|g__Bacteroides	1.0368066356
+UniRef50_F3ZPH8: DEAD/DEAH box helicase domain protein	1.0319917441
+UniRef50_F3ZPH8: DEAD/DEAH box helicase domain protein|g__Bacteroides	1.0319917441
+UniRef50_R5S0C0	1.0319917441
+UniRef50_R5S0C0|g__Bacteroides	1.0319917441
+UniRef50_R5S2A9: DNA topoisomerase	1.0319917441
+UniRef50_R5S2A9: DNA topoisomerase|g__Bacteroides	1.0319917441
+UniRef50_E4T5E0: DNA polymerase III subunit beta	1.0256410256
+UniRef50_E4T5E0: DNA polymerase III subunit beta|g__Bacteroides	1.0256410256
+UniRef50_R5USZ9	1.0256410256
+UniRef50_R5USZ9|g__Bacteroides	1.0256410256
+UniRef50_C6W0S7	1.0193679918
+UniRef50_C6W0S7|g__Bacteroides	1.0193679918
+UniRef50_F0R3K7	1.0193679918
+UniRef50_F0R3K7|g__Bacteroides	1.0193679918
+UniRef50_R6AMD8	1.0193679918
+UniRef50_R6AMD8|g__Bacteroides	1.0193679918
+UniRef50_R6ACB7	1.0167890221
+UniRef50_R6ACB7|g__Bacteroides	1.0167890221
+UniRef50_D6Z4R5: Phosphonopyruvate decarboxylase	1.0162601626
+UniRef50_D6Z4R5: Phosphonopyruvate decarboxylase|g__Bacteroides	1.0162601626
+UniRef50_Q8AAT0	1.0162601626
+UniRef50_Q8AAT0|g__Bacteroides	1.0162601626
+UniRef50_R6LJY6: Aldose 1-epimerase	1.0162601626
+UniRef50_R6LJY6: Aldose 1-epimerase|g__Bacteroides	1.0162601626
+UniRef50_R6XYG2: Signal transduction histidine kinase	1.0162601626
+UniRef50_R6XYG2: Signal transduction histidine kinase|g__Bacteroides	1.0162601626
+UniRef50_E6SR52: Glycoside hydrolase family 2 TIM barrel	1.0148907969
+UniRef50_E6SR52: Glycoside hydrolase family 2 TIM barrel|g__Bacteroides	1.014890797
+UniRef50_R5CR17: Lipid A disaccharide synthase	1.0131712259
+UniRef50_R5CR17: Lipid A disaccharide synthase|g__Bacteroides	1.0131712259
+UniRef50_R5W1I4	1.0131712259
+UniRef50_R5W1I4|g__Bacteroides	1.0131712259
+UniRef50_R5F9D0: Carboxynorspermidine decarboxylase	1.0101010101
+UniRef50_R5F9D0: Carboxynorspermidine decarboxylase|g__Bacteroides	1.0101010101
+UniRef50_R6SEZ6: dTDP-glucose 4,6-dehydratase	1.0101010101
+UniRef50_R6SEZ6: dTDP-glucose 4,6-dehydratase|g__Bacteroides	1.0101010101
+UniRef50_R5S9I0	1.0055304173
+UniRef50_R5S9I0|g__Bacteroides	1.0055304173
+UniRef50_K6A700	1.0040160643
+UniRef50_K6A700|g__Bacteroides	1.0040160643
+UniRef50_Q8AAR5: Tyrosine-protein kinase ptk involved in exopolysaccharide biosynthesis	1.0040160643
+UniRef50_Q8AAR5: Tyrosine-protein kinase ptk involved in exopolysaccharide biosynthesis|g__Bacteroides	1.0040160643
+UniRef50_D6D1V7: Glycosyl hydrolase family 71	1.0010010010
+UniRef50_D6D1V7: Glycosyl hydrolase family 71|g__Bacteroides	1.001001001
+UniRef50_Q5LIJ7: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase	1.0010010010
+UniRef50_Q5LIJ7: UDP-N-acetylglucosamine--N-acetylmuramyl-(pentapeptide) pyrophosphoryl-undecaprenol N-acetylglucosamine transferase|g__Bacteroides	1.001001001
+UniRef50_R7PCK6: Acyltransferase	1.0010010010
+UniRef50_R7PCK6: Acyltransferase|g__Bacteroides	1.001001001
+UniRef50_R6VPD1	0.9990009990
+UniRef50_R6VPD1|g__Bacteroides	0.999000999
+UniRef50_G8UIS7: Transposase, IS116/IS110/IS902 family	0.9980039920
+UniRef50_G8UIS7: Transposase, IS116/IS110/IS902 family|g__Bacteroides	0.998003992
+UniRef50_R6A607: LysM domain protein	0.9980039920
+UniRef50_R6A607: LysM domain protein|g__Bacteroides	0.998003992
+UniRef50_W0F1V4: Transcriptional regulator	0.9980039920
+UniRef50_W0F1V4: Transcriptional regulator|g__Bacteroides	0.998003992
+UniRef50_D5EW43: Endoribonuclease L-PSP family protein	0.9950248756
+UniRef50_D5EW43: Endoribonuclease L-PSP family protein|g__Bacteroides	0.9950248756
+UniRef50_R7DJ00	0.9950248756
+UniRef50_R7DJ00|g__Bacteroides	0.9950248756
+UniRef50_F0R5K7	0.9920634921
+UniRef50_F0R5K7|g__Bacteroides	0.9920634921
+UniRef50_R6FAN6	0.9920634921
+UniRef50_R6FAN6|g__Bacteroides	0.9920634921
+UniRef50_R6XYW2	0.9920634921
+UniRef50_R6XYW2|g__Bacteroides	0.9920634921
+UniRef50_R5V7Y5	0.9910802775
+UniRef50_R5V7Y5|g__Bacteroides	0.9910802775
+UniRef50_K6BE56	0.9891196835
+UniRef50_K6BE56|g__Bacteroides	0.9891196835
+UniRef50_R5NU14: Glycosyl hydrolase family 88	0.9891196835
+UniRef50_R5NU14: Glycosyl hydrolase family 88|g__Bacteroides	0.9891196835
+UniRef50_R6L7L5: ABC transporter ATP-binding protein	0.9861932939
+UniRef50_R6L7L5: ABC transporter ATP-binding protein|g__Bacteroides	0.9861932939
+UniRef50_Q3AUF2: Phosphoribosylglycinamide formyltransferase 2	0.9832841691
+UniRef50_Q3AUF2: Phosphoribosylglycinamide formyltransferase 2|g__Bacteroides	0.9832841691
+UniRef50_Q8A1Z3: Putatuve glycosylhydrolase	0.9803921569
+UniRef50_Q8A1Z3: Putatuve glycosylhydrolase|g__Bacteroides	0.9803921569
+UniRef50_R7DGM8	0.9803921569
+UniRef50_R7DGM8|g__Bacteroides	0.9803921569
+UniRef50_R7LCF1	0.9803921569
+UniRef50_R7LCF1|g__Bacteroides	0.9803921569
+UniRef50_B0NP73: Glycosyltransferase, group 1 family protein	0.9775171065
+UniRef50_B0NP73: Glycosyltransferase, group 1 family protein|g__Bacteroides	0.9775171065
+UniRef50_Q8A684: 1-deoxy-D-xylulose 5-phosphate reductoisomerase	0.9775171065
+UniRef50_Q8A684: 1-deoxy-D-xylulose 5-phosphate reductoisomerase|g__Bacteroides	0.9775171065
+UniRef50_R7NTP3: Glutamine-dependent carbamyl phosphate synthetase	0.9765625000
+UniRef50_R7NTP3: Glutamine-dependent carbamyl phosphate synthetase|g__Bacteroides	0.9765625
+UniRef50_F3ZUS7: ATP synthase subunit a	0.9746588694
+UniRef50_F3ZUS7: ATP synthase subunit a|g__Bacteroides	0.9746588694
+UniRef50_R5K881	0.9746588694
+UniRef50_R5K881|g__Bacteroides	0.9746588694
+UniRef50_R5NW37	0.9746588694
+UniRef50_R5NW37|g__Bacteroides	0.9746588694
+UniRef50_R5M3D3: Peptidase S9A/B/C family catalytic domain protein	0.9689942952
+UniRef50_R5M3D3: Peptidase S9A/B/C family catalytic domain protein|g__Bacteroides	0.9689942952
+UniRef50_D6D387: Relaxase/Mobilisation nuclease domain	0.9689922481
+UniRef50_D6D387: Relaxase/Mobilisation nuclease domain|g__Bacteroides	0.9689922481
+UniRef50_E0RYL3: UDP-N-acetylglucosamine 2-epimerase	0.9689922481
+UniRef50_E0RYL3: UDP-N-acetylglucosamine 2-epimerase|g__Bacteroides	0.9689922481
+UniRef50_R5ZWQ4: Isocitrate dehydrogenase [NADP]	0.9689922481
+UniRef50_R5ZWQ4: Isocitrate dehydrogenase [NADP]|g__Bacteroides	0.9689922481
+UniRef50_R7DKK4	0.9689922481
+UniRef50_R7DKK4|g__Bacteroides	0.9689922481
+UniRef50_R7NRS3: Aminotransferase	0.9689922481
+UniRef50_R7NRS3: Aminotransferase|g__Bacteroides	0.9689922481
+UniRef50_Q2S1Q6: DNA-directed RNA polymerase subunit beta'	0.9675858732
+UniRef50_Q2S1Q6: DNA-directed RNA polymerase subunit beta'|g__Bacteroides	0.9675858732
+UniRef50_C9RPC9	0.9661835749
+UniRef50_C9RPC9|g__Bacteroides	0.9661835749
+UniRef50_F9D1D7: Aminopeptidase C (Bleomycin hydrolase)	0.9661835749
+UniRef50_F9D1D7: Aminopeptidase C (Bleomycin hydrolase)|g__Bacteroides	0.9661835749
+UniRef50_Q9TMM9: Elongation factor Tu, apicoplast	0.9661835749
+UniRef50_Q9TMM9: Elongation factor Tu, apicoplast|g__Bacteroides	0.9661835749
+UniRef50_R5CGY7	0.9661835749
+UniRef50_R5CGY7|g__Bacteroides	0.9661835749
+UniRef50_R5I2S0	0.9661835749
+UniRef50_R5I2S0|g__Bacteroides	0.9661835749
+UniRef50_R6K531: Uracil-xanthine permease	0.9661835749
+UniRef50_R6K531: Uracil-xanthine permease|g__Bacteroides	0.9661835749
+UniRef50_R7KRX4: Anti-sigma factor	0.9661835749
+UniRef50_R7KRX4: Anti-sigma factor|g__Bacteroides	0.9661835749
+UniRef50_R7LKK3: ABC-2 type transporter	0.9661835749
+UniRef50_R7LKK3: ABC-2 type transporter|g__Bacteroides	0.9661835749
+UniRef50_B0NMV2	0.9633911368
+UniRef50_B0NMV2|g__Bacteroides	0.9633911368
+UniRef50_C6XUQ9: N-acetylglucosamine-6-phosphate deacetylase	0.9633911368
+UniRef50_C6XUQ9: N-acetylglucosamine-6-phosphate deacetylase|g__Bacteroides	0.9633911368
+UniRef50_R6JHS2	0.9624639076
+UniRef50_R6JHS2|g__Bacteroides	0.9624639076
+UniRef50_R6APR2: TonB-dependent receptor	0.9606147935
+UniRef50_R6APR2: TonB-dependent receptor|g__Bacteroides	0.9606147935
+UniRef50_Q8A351	0.9578544061
+UniRef50_Q8A351|g__Bacteroides	0.9578544061
+UniRef50_R5K7V2: Aminotransferase class I and II	0.9578544061
+UniRef50_R5K7V2: Aminotransferase class I and II|g__Bacteroides	0.9578544061
+UniRef50_D3QZF7: UDP-N-acetylglucosamine 2-epimerase	0.9551098376
+UniRef50_D3QZF7: UDP-N-acetylglucosamine 2-epimerase|g__Bacteroides	0.9551098376
+UniRef50_Q8A539	0.9523809524
+UniRef50_Q8A539|g__Bacteroides	0.9523809524
+UniRef50_Q8A5X7: Galactose-binding-like protein	0.9523809524
+UniRef50_Q8A5X7: Galactose-binding-like protein|g__Bacteroides	0.9523809524
+UniRef50_R6JCQ7	0.9523809524
+UniRef50_R6JCQ7|g__Bacteroides	0.9523809524
+UniRef50_R7CTU0: Glycoside hydrolase family 15	0.9523809524
+UniRef50_R7CTU0: Glycoside hydrolase family 15|g__Bacteroides	0.9523809524
+UniRef50_R5JMV2	0.9517132877
+UniRef50_R5JMV2|g__Bacteroides	0.9517132877000001
+UniRef50_K0CZ06: Glycosyl hydrolase	0.9496676163
+UniRef50_K0CZ06: Glycosyl hydrolase|g__Bacteroides	0.9496676163
+UniRef50_R5LPK8	0.9496676163
+UniRef50_R5LPK8|g__Bacteroides	0.9496676163
+UniRef50_R5ETJ9	0.9469696970
+UniRef50_R5ETJ9|g__Bacteroides	0.946969697
+UniRef50_R6JJS8	0.9469696970
+UniRef50_R6JJS8|g__Bacteroides	0.946969697
+UniRef50_W4UNV5: Protein translocase subunit SecA	0.9460737938
+UniRef50_W4UNV5: Protein translocase subunit SecA|g__Bacteroides	0.9460737938
+UniRef50_R5MKR5: Concanavalin A-like lectin/glucanase	0.9442870633
+UniRef50_R5MKR5: Concanavalin A-like lectin/glucanase|g__Bacteroides	0.9442870633
+UniRef50_R5UD95	0.9442870633
+UniRef50_R5UD95|g__Bacteroides	0.9442870633
+UniRef50_B1LE56: Cysteine desulfurase	0.9416195857
+UniRef50_B1LE56: Cysteine desulfurase|g__Bacteroides	0.9416195857
+UniRef50_R7EVE0: L-serine ammonia-lyase	0.9416195857
+UniRef50_R7EVE0: L-serine ammonia-lyase|g__Bacteroides	0.9416195857
+UniRef50_Q8A3N6	0.9389671362
+UniRef50_Q8A3N6|g__Bacteroides	0.9389671362
+UniRef50_Q8AAZ4: SusD homolog	0.9389671362
+UniRef50_Q8AAZ4: SusD homolog|g__Bacteroides	0.9389671362
+UniRef50_R7EDB9: L-fucose:H+ symporter permease	0.9389671362
+UniRef50_R7EDB9: L-fucose:H+ symporter permease|g__Bacteroides	0.9389671362
+UniRef50_B0NP74	0.9363295880
+UniRef50_B0NP74|g__Bacteroides	0.936329588
+UniRef50_R7E276: MbeB-like domain protein	0.9363295880
+UniRef50_R7E276: MbeB-like domain protein|g__Bacteroides	0.936329588
+UniRef50_I1YR97: S-adenosylmethionine:tRNA ribosyltransferase-isomerase	0.9337068161
+UniRef50_I1YR97: S-adenosylmethionine:tRNA ribosyltransferase-isomerase|g__Bacteroides	0.9337068161
+UniRef50_W6PQ03: Membrane protein, putative	0.9319680666
+UniRef50_W6PQ03: Membrane protein, putative|g__Bacteroides	0.9319680667000001
+UniRef50_D4WJ09: Putative 3-deoxy-D-manno-octulosonic-acid transferase	0.9310986965
+UniRef50_D4WJ09: Putative 3-deoxy-D-manno-octulosonic-acid transferase|g__Bacteroides	0.9310986965
+UniRef50_P0AFF4: Nucleoside permease NupG	0.9310986965
+UniRef50_P0AFF4: Nucleoside permease NupG|g__Bacteroides	0.9310986965
+UniRef50_R7P669	0.9310986965
+UniRef50_R7P669|g__Bacteroides	0.9310986965
+UniRef50_Q89ZU2: Glycoside transferase family 4	0.9285051068
+UniRef50_Q89ZU2: Glycoside transferase family 4|g__Bacteroides	0.9285051068
+UniRef50_R5S5U0: Glycosyltransferase group 1 family protein	0.9285051068
+UniRef50_R5S5U0: Glycosyltransferase group 1 family protein|g__Bacteroides	0.9285051068
+UniRef50_R6V8L4	0.9285051068
+UniRef50_R6V8L4|g__Bacteroides	0.9285051068
+UniRef50_D9RRZ7: HD domain protein	0.9259259259
+UniRef50_D9RRZ7: HD domain protein|g__Bacteroides	0.9259259259
+UniRef50_R6CU88	0.9210247275
+UniRef50_R6CU88|g__Bacteroides	0.9210247275
+UniRef50_I2EWF1: Peptidase M16 domain protein	0.9208103131
+UniRef50_I2EWF1: Peptidase M16 domain protein|g__Bacteroides	0.9208103131
+UniRef50_R5NYX5: Sodium ion-translocating decarboxylase beta subunit	0.9208103131
+UniRef50_R5NYX5: Sodium ion-translocating decarboxylase beta subunit|g__Bacteroides	0.9208103131
+UniRef50_R5U7R5	0.9208103131
+UniRef50_R5U7R5|g__Bacteroides	0.9208103131
+UniRef50_R5UJ48	0.9208103131
+UniRef50_R5UJ48|g__Bacteroides	0.9208103131
+UniRef50_R6FJ75: Beta-N-acetylhexosaminidase	0.9195402299
+UniRef50_R6FJ75: Beta-N-acetylhexosaminidase|g__Bacteroides	0.9195402299
+UniRef50_K5BT09	0.9157509158
+UniRef50_K5BT09|g__Bacteroides	0.9157509158
+UniRef50_Q5L8L7: ATP-dependent Clp protease ATP-binding subunit ClpX	0.9132420091
+UniRef50_Q5L8L7: ATP-dependent Clp protease ATP-binding subunit ClpX|g__Bacteroides	0.9132420091
+UniRef50_R6US20	0.9107468124
+UniRef50_R6US20|g__Bacteroides	0.9107468124
+UniRef50_R7PBD0	0.9107468124
+UniRef50_R7PBD0|g__Bacteroides	0.9107468124
+UniRef50_R6XRD6: Alpha-1 2-mannosidase putative	0.9080613169
+UniRef50_R6XRD6: Alpha-1 2-mannosidase putative|g__Bacteroides	0.9080613169
+UniRef50_B2RLA8: Imidazolonepropionase	0.9057971014
+UniRef50_B2RLA8: Imidazolonepropionase|g__Bacteroides	0.9057971014
+UniRef50_R5AQW0: Tetrahydrofolate synthase	0.9057971014
+UniRef50_R5AQW0: Tetrahydrofolate synthase|g__Bacteroides	0.9057971014
+UniRef50_D5EZC2: CBS/transporter associated domain protein	0.9033423668
+UniRef50_D5EZC2: CBS/transporter associated domain protein|g__Bacteroides	0.9033423668
+UniRef50_Q838L2: L-rhamnose isomerase	0.9033423668
+UniRef50_Q838L2: L-rhamnose isomerase|g__Bacteroides	0.9033423668
+UniRef50_R7JE67	0.9033423668
+UniRef50_R7JE67|g__Bacteroides	0.9033423668
+UniRef50_D5EVI1: GTPase HflX	0.9009009009
+UniRef50_D5EVI1: GTPase HflX|g__Bacteroides	0.9009009009
+UniRef50_Q5LGW9: Alpha-N-acetylgalactosaminidase	0.9009009009
+UniRef50_Q5LGW9: Alpha-N-acetylgalactosaminidase|g__Bacteroides	0.9009009009
+UniRef50_Q7MU77: Phosphoglycerate kinase	0.9009009009
+UniRef50_Q7MU77: Phosphoglycerate kinase|g__Bacteroides	0.9009009009
+UniRef50_Q8A5G2: Transposase	0.9009009009
+UniRef50_Q8A5G2: Transposase|g__Bacteroides	0.9009009009
+UniRef50_Q64VY8: ABC transporter permease protein	0.8952551477
+UniRef50_Q64VY8: ABC transporter permease protein|g__Bacteroides	0.8952551477
+UniRef50_A6KY74: Two-component system sensor histidine kinase	0.8936550492
+UniRef50_A6KY74: Two-component system sensor histidine kinase|g__Bacteroides	0.8936550492
+UniRef50_R5K3I7: TonB-dependent Receptor Plug domain-containing protein	0.8928571429
+UniRef50_R5K3I7: TonB-dependent Receptor Plug domain-containing protein|g__Bacteroides	0.8928571429
+UniRef50_Q8A5M5	0.8888888889
+UniRef50_Q8A5M5|g__Bacteroides	0.8888888889
+UniRef50_Q8ZFX5: Histidinol dehydrogenase	0.8818342152
+UniRef50_Q8ZFX5: Histidinol dehydrogenase|g__Bacteroides	0.8818342152
+UniRef50_R7J412: Pyruvate-flavodoxin oxidoreductase	0.8802816901
+UniRef50_R7J412: Pyruvate-flavodoxin oxidoreductase|g__Bacteroides	0.8802816901
+UniRef50_B2GKX1: O-acetylhomoserine (Thiol)-lyase	0.8795074758
+UniRef50_B2GKX1: O-acetylhomoserine (Thiol)-lyase|g__Bacteroides	0.8795074758
+UniRef50_D3R5Q5: O-acetyl-L-homoserine sulfhydrolase	0.8795074758
+UniRef50_D3R5Q5: O-acetyl-L-homoserine sulfhydrolase|g__Bacteroides	0.8795074758
+UniRef50_Q8A285	0.8795074758
+UniRef50_Q8A285|g__Bacteroides	0.8795074758
+UniRef50_D6D518: Myo-inositol-1-phosphate synthase	0.8771929825
+UniRef50_D6D518: Myo-inositol-1-phosphate synthase|g__Bacteroides	0.8771929825
+UniRef50_R5FDQ5	0.8771929825
+UniRef50_R5FDQ5|g__Bacteroides	0.8771929825
+UniRef50_R6V5M5: Radical SAM domain protein	0.8771929825
+UniRef50_R6V5M5: Radical SAM domain protein|g__Bacteroides	0.8771929825
+UniRef50_R7NU49: Aspartokinase I-homoserine dehydrogenase	0.8760402979
+UniRef50_R7NU49: Aspartokinase I-homoserine dehydrogenase|g__Bacteroides	0.8760402979
+UniRef50_Q8A2T6: S-adenosylmethionine synthase	0.8748906387
+UniRef50_Q8A2T6: S-adenosylmethionine synthase|g__Bacteroides	0.8748906387
+UniRef50_Q8A307	0.8748906387
+UniRef50_Q8A307|g__Bacteroides	0.8748906387
+UniRef50_R5PHV4	0.8748906387
+UniRef50_R5PHV4|g__Bacteroides	0.8748906387
+UniRef50_R5S220	0.8748906387
+UniRef50_R5S220|g__Bacteroides	0.8748906387
+UniRef50_R6L8W2: BNR/Asp-box repeat protein	0.8748906387
+UniRef50_R6L8W2: BNR/Asp-box repeat protein|g__Bacteroides	0.8748906387
+UniRef50_R7E0Q9	0.8748906387
+UniRef50_R7E0Q9|g__Bacteroides	0.8748906387
+UniRef50_R7GUK0: DEAD/DEAH box helicase	0.8748906387
+UniRef50_R7GUK0: DEAD/DEAH box helicase|g__Bacteroides	0.8748906387
+UniRef50_D5ESJ2: Inositol-3-phosphate synthase	0.8726003490
+UniRef50_D5ESJ2: Inositol-3-phosphate synthase|g__Bacteroides	0.872600349
+UniRef50_D5EV84: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase	0.8703220191
+UniRef50_D5EV84: UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase|g__Bacteroides	0.8703220191
+UniRef50_R6B579: Galacturan 1 4-alpha-galacturonidase	0.8703220191
+UniRef50_R6B579: Galacturan 1 4-alpha-galacturonidase|g__Bacteroides	0.8703220191
+UniRef50_R6YIA5: Peptidase M23 family	0.8703220191
+UniRef50_R6YIA5: Peptidase M23 family|g__Bacteroides	0.8703220191
+UniRef50_R7EXU7: Ribosomal protein S12 methylthiotransferase RimO	0.8703220191
+UniRef50_R7EXU7: Ribosomal protein S12 methylthiotransferase RimO|g__Bacteroides	0.8703220191
+UniRef50_Q7MUW1: UDP-N-acetylglucosamine 1-carboxyvinyltransferase	0.8658008658
+UniRef50_Q7MUW1: UDP-N-acetylglucosamine 1-carboxyvinyltransferase|g__Bacteroides	0.8658008658
+UniRef50_A6KY55: Conserved protein found in conjugate transposon	0.8635578584
+UniRef50_A6KY55: Conserved protein found in conjugate transposon|g__Bacteroides	0.8635578584
+UniRef50_R5CLY4: MATE efflux family protein	0.8635578584
+UniRef50_R5CLY4: MATE efflux family protein|g__Bacteroides	0.8635578584
+UniRef50_R6UXK7	0.8635578584
+UniRef50_R6UXK7|g__Bacteroides	0.8635578584
+UniRef50_R6XTA9: Transporter major facilitator family protein	0.8613264427
+UniRef50_R6XTA9: Transporter major facilitator family protein|g__Bacteroides	0.8613264427
+UniRef50_R7NJF0: Cell division protein FtsZ	0.8591065292
+UniRef50_R7NJF0: Cell division protein FtsZ|g__Bacteroides	0.8591065292
+UniRef50_R6DFM3: Aspartokinase	0.8568980291
+UniRef50_R6DFM3: Aspartokinase|g__Bacteroides	0.8568980291
+UniRef50_R6FS39: Hsp90-like protein	0.8568980291
+UniRef50_R6FS39: Hsp90-like protein|g__Bacteroides	0.8568980291
+UniRef50_K0WJ22: Uracil-xanthine permease/xanthine permease	0.8547008547
+UniRef50_K0WJ22: Uracil-xanthine permease/xanthine permease|g__Bacteroides	0.8547008547
+UniRef50_R5TZY1: Ribonuclease BN	0.8547008547
+UniRef50_R5TZY1: Ribonuclease BN|g__Bacteroides	0.8547008547
+UniRef50_R6VND8	0.8547008547
+UniRef50_R6VND8|g__Bacteroides	0.8547008547
+UniRef50_R5I7I3	0.8525149190
+UniRef50_R5I7I3|g__Bacteroides	0.852514919
+UniRef50_E6SWU3: DUF234 DEXX-box ATPase	0.8503401361
+UniRef50_E6SWU3: DUF234 DEXX-box ATPase|g__Bacteroides	0.8503401361
+UniRef50_Q8REJ9: ATPase	0.8503401361
+UniRef50_Q8REJ9: ATPase|g__Bacteroides	0.8503401361
+UniRef50_F4LMG6: Phosphoenolpyruvate phosphomutase	0.8474576271
+UniRef50_F4LMG6: Phosphoenolpyruvate phosphomutase|g__Bacteroides	0.8474576271
+UniRef50_F0QZ62	0.8460236887
+UniRef50_F0QZ62|g__Bacteroides	0.8460236887
+UniRef50_R7KWB0	0.8460236887
+UniRef50_R7KWB0|g__Bacteroides	0.8460236887
+UniRef50_Q8A589	0.8438818565
+UniRef50_Q8A589|g__Bacteroides	0.8438818565
+UniRef50_R6DK68	0.8438818565
+UniRef50_R6DK68|g__Bacteroides	0.8438818565
+UniRef50_R5SQC5	0.8428271256
+UniRef50_R5SQC5|g__Bacteroides	0.8428271256
+UniRef50_Q04IA2: Glucose-6-phosphate isomerase	0.8417508418
+UniRef50_Q04IA2: Glucose-6-phosphate isomerase|g__Bacteroides	0.8417508418
+UniRef50_R6M5X0	0.8417508418
+UniRef50_R6M5X0|g__Bacteroides	0.8417508418
+UniRef50_R5JQA5	0.8396305626
+UniRef50_R5JQA5|g__Bacteroides	0.8396305626
+UniRef50_R5Y371	0.8396305626
+UniRef50_R5Y371|g__Bacteroides	0.8396305626
+UniRef50_R7EI38: Magnesium transporter	0.8396305626
+UniRef50_R7EI38: Magnesium transporter|g__Bacteroides	0.8396305626
+UniRef50_D6D118: F5/8 type C domain	0.8375209380
+UniRef50_D6D118: F5/8 type C domain|g__Bacteroides	0.837520938
+UniRef50_R5VG84: Protein translocase subunit SecY	0.8375209380
+UniRef50_R5VG84: Protein translocase subunit SecY|g__Bacteroides	0.837520938
+UniRef50_R6A0Z5: FeS assembly protein SufD	0.8375209380
+UniRef50_R6A0Z5: FeS assembly protein SufD|g__Bacteroides	0.837520938
+UniRef50_R6XFB4	0.8375209380
+UniRef50_R6XFB4|g__Bacteroides	0.837520938
+UniRef50_T2KHY1: Ribonucleoside-diphosphate reductase	0.8375209380
+UniRef50_T2KHY1: Ribonucleoside-diphosphate reductase|g__Bacteroides	0.837520938
+UniRef50_R5K6Q7	0.8354218881
+UniRef50_R5K6Q7|g__Bacteroides	0.8354218881
+UniRef50_R5PHZ4: Outer membrane efflux protein	0.8354218881
+UniRef50_R5PHZ4: Outer membrane efflux protein|g__Bacteroides	0.8354218881
+UniRef50_R6LNE3: Outer membrane efflux protein	0.8354218881
+UniRef50_R6LNE3: Outer membrane efflux protein|g__Bacteroides	0.8354218881
+UniRef50_F4C8Z9	0.8343763037
+UniRef50_F4C8Z9|g__Bacteroides	0.8343763037
+UniRef50_R6JSE0: HRDC domain protein	0.8343763037
+UniRef50_R6JSE0: HRDC domain protein|g__Bacteroides	0.8343763037
+UniRef50_Q89ZD9	0.8333333333
+UniRef50_Q89ZD9|g__Bacteroides	0.8333333333
+UniRef50_R6C179: Bacterial extracellular solute-binding protein	0.8333333333
+UniRef50_R6C179: Bacterial extracellular solute-binding protein|g__Bacteroides	0.8333333333
+UniRef50_R6YBT5: Gliding motility-associated protein GldE	0.8312551953
+UniRef50_R6YBT5: Gliding motility-associated protein GldE|g__Bacteroides	0.8312551953
+UniRef50_W0ERH5: Conjugate transposon protein	0.8312551953
+UniRef50_W0ERH5: Conjugate transposon protein|g__Bacteroides	0.8312551953
+UniRef50_R5NYT6: Hydrophobic domain protein	0.8291873964
+UniRef50_R5NYT6: Hydrophobic domain protein|g__Bacteroides	0.8291873964
+UniRef50_R6E1S9	0.8291873964
+UniRef50_R6E1S9|g__Bacteroides	0.8291873964
+UniRef50_A4X5J8: 4-diphosphocytidyl-2C-methyl-D-erythritol synthase	0.8250825083
+UniRef50_A4X5J8: 4-diphosphocytidyl-2C-methyl-D-erythritol synthase|g__Bacteroides	0.8250825083
+UniRef50_R6E1I6	0.8250825083
+UniRef50_R6E1I6|g__Bacteroides	0.8250825083
+UniRef50_Q64QS2: Histidine--tRNA ligase	0.8230452675
+UniRef50_Q64QS2: Histidine--tRNA ligase|g__Bacteroides	0.8230452675
+UniRef50_R5U378	0.8230452675
+UniRef50_R5U378|g__Bacteroides	0.8230452675
+UniRef50_R6K5T5: Arylsulfatase	0.8210180624
+UniRef50_R6K5T5: Arylsulfatase|g__Bacteroides	0.8210180624
+UniRef50_E6WX55: Xylose isomerase	0.8190008190
+UniRef50_E6WX55: Xylose isomerase|g__Bacteroides	0.819000819
+UniRef50_R5JNL0	0.8190008190
+UniRef50_R5JNL0|g__Bacteroides	0.819000819
+UniRef50_R6M7U0: Transporter major facilitator family protein	0.8190008190
+UniRef50_R6M7U0: Transporter major facilitator family protein|g__Bacteroides	0.819000819
+UniRef50_R5AK03	0.8179959100
+UniRef50_R5AK03|g__Bacteroides	0.81799591
+UniRef50_I1YT44: DNA mismatch repair protein MutS	0.8155191041
+UniRef50_I1YT44: DNA mismatch repair protein MutS|g__Bacteroides	0.8155191041000001
+UniRef50_D5H9Z4: Sigma-54 dependent DNA-binding response regulator, Fis family	0.8149959250
+UniRef50_D5H9Z4: Sigma-54 dependent DNA-binding response regulator, Fis family|g__Bacteroides	0.814995925
+UniRef50_I9SKL2	0.8120178644
+UniRef50_I9SKL2|g__Bacteroides	0.8120178644
+UniRef50_R7EVE7	0.8110300081
+UniRef50_R7EVE7|g__Bacteroides	0.8110300081
+UniRef50_Q8A7K8: Replicative DNA helicase	0.8090614887
+UniRef50_Q8A7K8: Replicative DNA helicase|g__Bacteroides	0.8090614887
+UniRef50_R5RIY3	0.8090614887
+UniRef50_R5RIY3|g__Bacteroides	0.8090614887
+UniRef50_R6AKS2	0.8090614887
+UniRef50_R6AKS2|g__Bacteroides	0.8090614887
+UniRef50_A6L2B0: Glycoside hydrolase family 28	0.8071025020
+UniRef50_A6L2B0: Glycoside hydrolase family 28|g__Bacteroides	0.807102502
+UniRef50_D7I9G0: F5/8 type C domain-containing protein	0.8071025020
+UniRef50_D7I9G0: F5/8 type C domain-containing protein|g__Bacteroides	0.807102502
+UniRef50_Q89YJ1	0.8071025020
+UniRef50_Q89YJ1|g__Bacteroides	0.807102502
+UniRef50_R5EPL7	0.8071025020
+UniRef50_R5EPL7|g__Bacteroides	0.807102502
+UniRef50_R5TX52: Major facilitator superfamily MFS_1	0.8071025020
+UniRef50_R5TX52: Major facilitator superfamily MFS_1|g__Bacteroides	0.807102502
+UniRef50_R6ALV2: Transglycosylase SLT domain protein	0.8071025020
+UniRef50_R6ALV2: Transglycosylase SLT domain protein|g__Bacteroides	0.807102502
+UniRef50_F9D499: Chromosomal replication initiator protein DnaA	0.8051529791
+UniRef50_F9D499: Chromosomal replication initiator protein DnaA|g__Bacteroides	0.8051529791
+UniRef50_Q7UIA7: 3-isopropylmalate dehydratase large subunit	0.8032128514
+UniRef50_Q7UIA7: 3-isopropylmalate dehydratase large subunit|g__Bacteroides	0.8032128514
+UniRef50_D6D1E1: Predicted unsaturated glucuronyl hydrolase involved in regulation of bacterial surface properties, and related proteins	0.8012820513
+UniRef50_D6D1E1: Predicted unsaturated glucuronyl hydrolase involved in regulation of bacterial surface properties, and related proteins|g__Bacteroides	0.8012820513
+UniRef50_R5K6U5: Peptidase C1-like family protein	0.8012820513
+UniRef50_R5K6U5: Peptidase C1-like family protein|g__Bacteroides	0.8012820513
+UniRef50_R5Y5Y4	0.7993605116
+UniRef50_R5Y5Y4|g__Bacteroides	0.7993605116
+UniRef50_A6LEU2: UDP-N-acetylmuramate--L-alanine ligase	0.7974481659
+UniRef50_A6LEU2: UDP-N-acetylmuramate--L-alanine ligase|g__Bacteroides	0.7974481659
+UniRef50_D6D175: GDSL-like Lipase/Acylhydrolase	0.7974481659
+UniRef50_D6D175: GDSL-like Lipase/Acylhydrolase|g__Bacteroides	0.7974481659
+UniRef50_P58696: Asparagine--tRNA ligase	0.7974481659
+UniRef50_P58696: Asparagine--tRNA ligase|g__Bacteroides	0.7974481659
+UniRef50_R5JPW7: TolC family type I secretion outer membrane protein	0.7974481659
+UniRef50_R5JPW7: TolC family type I secretion outer membrane protein|g__Bacteroides	0.7974481659
+UniRef50_R6MHI2: Mobilization protein	0.7974481659
+UniRef50_R6MHI2: Mobilization protein|g__Bacteroides	0.7974481659
+UniRef50_R6B8Z4: Response regulator receiver domain protein	0.7970652674
+UniRef50_R6B8Z4: Response regulator receiver domain protein|g__Bacteroides	0.7970652674
+UniRef50_Q0AVI1	0.7955449483
+UniRef50_Q0AVI1|g__Bacteroides	0.7955449483
+UniRef50_R5PCA6	0.7936507937
+UniRef50_R5PCA6|g__Bacteroides	0.7936507937
+UniRef50_Q8A2K7	0.7917656374
+UniRef50_Q8A2K7|g__Bacteroides	0.7917656374
+UniRef50_Q8A790: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)	0.7907354484
+UniRef50_Q8A790: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)|g__Bacteroides	0.7907354484
+UniRef50_R5N6E0: Arabinose-proton symporter	0.7898894155
+UniRef50_R5N6E0: Arabinose-proton symporter|g__Bacteroides	0.7898894155
+UniRef50_S3YU07	0.7898894155
+UniRef50_S3YU07|g__Bacteroides	0.7898894155
+UniRef50_Q89Z59: Probable type I restriction enzyme BthVORF4518P M protein	0.7880220646
+UniRef50_Q89Z59: Probable type I restriction enzyme BthVORF4518P M protein|g__Bacteroides	0.7880220646
+UniRef50_B0NU77	0.7861635220
+UniRef50_B0NU77|g__Bacteroides	0.786163522
+UniRef50_D4JAQ7	0.7861635220
+UniRef50_D4JAQ7|g__Bacteroides	0.786163522
+UniRef50_R7KQQ4: Sulfatase family protein	0.7861635220
+UniRef50_R7KQQ4: Sulfatase family protein|g__Bacteroides	0.786163522
+UniRef50_Q8A1R2: Sialic acid-specific 9-O-acetylesterase	0.7843137255
+UniRef50_Q8A1R2: Sialic acid-specific 9-O-acetylesterase|g__Bacteroides	0.7843137255
+UniRef50_R6B7R5	0.7843137255
+UniRef50_R6B7R5|g__Bacteroides	0.7843137255
+UniRef50_R6LCG3	0.7810977100
+UniRef50_R6LCG3|g__Bacteroides	0.78109771
+UniRef50_R5C5A0: Tetratricopeptide repeat protein	0.7806401249
+UniRef50_R5C5A0: Tetratricopeptide repeat protein|g__Bacteroides	0.7806401249
+UniRef50_R6KD20	0.7806401249
+UniRef50_R6KD20|g__Bacteroides	0.7806401249
+UniRef50_Q9HTD7: Aspartate ammonia-lyase	0.7788161994
+UniRef50_Q9HTD7: Aspartate ammonia-lyase|g__Bacteroides	0.7788161994
+UniRef50_R6CDJ5	0.7788161994
+UniRef50_R6CDJ5|g__Bacteroides	0.7788161994
+UniRef50_D6D584: Arylsulfatase A and related enzymes	0.7716049383
+UniRef50_D6D584: Arylsulfatase A and related enzymes|g__Bacteroides	0.7716049383
+UniRef50_R6CMZ9	0.7716049383
+UniRef50_R6CMZ9|g__Bacteroides	0.7716049383
+UniRef50_D3ICC6	0.7698229407
+UniRef50_D3ICC6|g__Bacteroides	0.7698229407
+UniRef50_Q7MWM7: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase	0.7698229407
+UniRef50_Q7MWM7: UDP-N-acetylmuramoyl-L-alanyl-D-glutamate--2,6-diaminopimelate ligase|g__Bacteroides	0.7698229407
+UniRef50_Q8A3G2: Virulence-associated protein E-like protein	0.7698229407
+UniRef50_Q8A3G2: Virulence-associated protein E-like protein|g__Bacteroides	0.7698229407
+UniRef50_R5C2D3	0.7698229407
+UniRef50_R5C2D3|g__Bacteroides	0.7698229407
+UniRef50_R6MJ95: Polysaccharide biosynthesis protein	0.7698229407
+UniRef50_R6MJ95: Polysaccharide biosynthesis protein|g__Bacteroides	0.7698229407
+UniRef50_R5GUG1	0.7680491551
+UniRef50_R5GUG1|g__Bacteroides	0.7680491551
+UniRef50_A6L4J4: Na+/solute symporter	0.7662835249
+UniRef50_A6L4J4: Na+/solute symporter|g__Bacteroides	0.7662835249
+UniRef50_R5RSK0	0.7662835249
+UniRef50_R5RSK0|g__Bacteroides	0.7662835249
+UniRef50_G8UQN8: Xaa-His dipeptidase	0.7645259939
+UniRef50_G8UQN8: Xaa-His dipeptidase|g__Bacteroides	0.7645259939
+UniRef50_R6XBT3: Pyruvate kinase	0.7645259939
+UniRef50_R6XBT3: Pyruvate kinase|g__Bacteroides	0.7645259939
+UniRef50_R5MS47: TonB-dependent receptor	0.7636502482
+UniRef50_R5MS47: TonB-dependent receptor|g__Bacteroides	0.7636502482
+UniRef50_Q8A7B0: Aminoacyl-histidine dipeptidase	0.7627765065
+UniRef50_Q8A7B0: Aminoacyl-histidine dipeptidase|g__Bacteroides	0.7627765065
+UniRef50_R5JLZ4	0.7610350076
+UniRef50_R5JLZ4|g__Bacteroides	0.7610350076
+UniRef50_R7H225	0.7610350076
+UniRef50_R7H225|g__Bacteroides	0.7610350076
+UniRef50_R6ADH8	0.7593014427
+UniRef50_R6ADH8|g__Bacteroides	0.7593014427
+UniRef50_D6D6G8: SusD family	0.7575757576
+UniRef50_D6D6G8: SusD family|g__Bacteroides	0.7575757576
+UniRef50_R6D0G3	0.7575757576
+UniRef50_R6D0G3|g__Bacteroides	0.7575757576
+UniRef50_R7DNV4: Outer membrane efflux protein	0.7558578987
+UniRef50_R7DNV4: Outer membrane efflux protein|g__Bacteroides	0.7558578987
+UniRef50_R5J8S8	0.7552870091
+UniRef50_R5J8S8|g__Bacteroides	0.7552870091
+UniRef50_Q8A8Y7: Fibronectin, type III-like fold	0.7541478130
+UniRef50_Q8A8Y7: Fibronectin, type III-like fold|g__Bacteroides	0.754147813
+UniRef50_R6DY62: Tetrahydrofolate synthase	0.7541478130
+UniRef50_R6DY62: Tetrahydrofolate synthase|g__Bacteroides	0.754147813
+UniRef50_R6JRP7: 6-phosphogluconate dehydrogenase, decarboxylating	0.7541478130
+UniRef50_R6JRP7: 6-phosphogluconate dehydrogenase, decarboxylating|g__Bacteroides	0.754147813
+UniRef50_R7KYE7	0.7541478130
+UniRef50_R7KYE7|g__Bacteroides	0.754147813
+UniRef50_Q8A551: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)	0.7530120482
+UniRef50_Q8A551: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)|g__Bacteroides	0.7530120482
+UniRef50_A6L4U5: Altronate oxidoreductase	0.7524454477
+UniRef50_A6L4U5: Altronate oxidoreductase|g__Bacteroides	0.7524454477
+UniRef50_R5JMK7	0.7507507508
+UniRef50_R5JMK7|g__Bacteroides	0.7507507508
+UniRef50_D6D0L5: Na+/proline symporter	0.7473841555
+UniRef50_D6D0L5: Na+/proline symporter|g__Bacteroides	0.7473841555
+UniRef50_R7DFF4	0.7473841555
+UniRef50_R7DFF4|g__Bacteroides	0.7473841555
+UniRef50_R5Y1M5: Excinuclease ABC subunit A	0.7465472191
+UniRef50_R5Y1M5: Excinuclease ABC subunit A|g__Bacteroides	0.7465472191
+UniRef50_H8KPI4: RagB/SusD family protein	0.7457121551
+UniRef50_H8KPI4: RagB/SusD family protein|g__Bacteroides	0.7457121551
+UniRef50_R5AML8: Pseudouridine synthase	0.7457121551
+UniRef50_R5AML8: Pseudouridine synthase|g__Bacteroides	0.7457121551
+UniRef50_G8UNX0: Outer membrane efflux protein	0.7423904974
+UniRef50_G8UNX0: Outer membrane efflux protein|g__Bacteroides	0.7423904974
+UniRef50_D6CWM9: Outer membrane cobalamin receptor protein	0.7407407407
+UniRef50_D6CWM9: Outer membrane cobalamin receptor protein|g__Bacteroides	0.7407407407
+UniRef50_P52043: Propionyl-CoA:succinate CoA transferase	0.7407407407
+UniRef50_P52043: Propionyl-CoA:succinate CoA transferase|g__Bacteroides	0.7407407407
+UniRef50_Q8A8I5	0.7390983001
+UniRef50_Q8A8I5|g__Bacteroides	0.7390983001
+UniRef50_R6KDW2	0.7358351729
+UniRef50_R6KDW2|g__Bacteroides	0.7358351729
+UniRef50_R5Q0I7: GH3 auxin-responsive promoter	0.7342143906
+UniRef50_R5Q0I7: GH3 auxin-responsive promoter|g__Bacteroides	0.7342143906
+UniRef50_R6M6C5: Bacterial sugar transferase	0.7342143906
+UniRef50_R6M6C5: Bacterial sugar transferase|g__Bacteroides	0.7342143906
+UniRef50_R6X0K5: ABC transporter ATP-binding protein	0.7342143906
+UniRef50_R6X0K5: ABC transporter ATP-binding protein|g__Bacteroides	0.7342143906
+UniRef50_A6L050: 2,3-bisphosphoglycerate-independent phosphoglycerate mutase	0.7326007326
+UniRef50_A6L050: 2,3-bisphosphoglycerate-independent phosphoglycerate mutase|g__Bacteroides	0.7326007326
+UniRef50_F3ZUL5: Amino acid/peptide transporter	0.7326007326
+UniRef50_F3ZUL5: Amino acid/peptide transporter|g__Bacteroides	0.7326007326
+UniRef50_Q64PR3	0.7326007326
+UniRef50_Q64PR3|g__Bacteroides	0.7326007326
+UniRef50_R6CT82	0.7315288954
+UniRef50_R6CT82|g__Bacteroides	0.7315288954
+UniRef50_A6L4L7: ATP synthase subunit beta	0.7309941520
+UniRef50_A6L4L7: ATP synthase subunit beta|g__Bacteroides	0.730994152
+UniRef50_R6V1Q7	0.7293946025
+UniRef50_R6V1Q7|g__Bacteroides	0.7293946025
+UniRef50_X5DW04: Membrane protein	0.7293946025
+UniRef50_X5DW04: Membrane protein|g__Bacteroides	0.7293946025
+UniRef50_D2QFV1: Phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase	0.7278020378
+UniRef50_D2QFV1: Phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase|g__Bacteroides	0.7278020378
+UniRef50_Q4FMW8: GMP synthase [glutamine-hydrolyzing]	0.7278020378
+UniRef50_Q4FMW8: GMP synthase [glutamine-hydrolyzing]|g__Bacteroides	0.7278020378
+UniRef50_Q8A3V7	0.7278020378
+UniRef50_Q8A3V7|g__Bacteroides	0.7278020378
+UniRef50_R6W503	0.7278020378
+UniRef50_R6W503|g__Bacteroides	0.7278020378
+UniRef50_D7IHX5: Endo-beta-N-acetylglucosaminidase F1	0.7262164125
+UniRef50_D7IHX5: Endo-beta-N-acetylglucosaminidase F1|g__Bacteroides	0.7262164125
+UniRef50_R7KFY3	0.7262164125
+UniRef50_R7KFY3|g__Bacteroides	0.7262164125
+UniRef50_R6UPJ0: F5/8 type C domain-containing protein	0.7254261879
+UniRef50_R6UPJ0: F5/8 type C domain-containing protein|g__Bacteroides	0.7254261879
+UniRef50_A6L2R5: L-arabinose isomerase	0.7246376812
+UniRef50_A6L2R5: L-arabinose isomerase|g__Bacteroides	0.7246376812
+UniRef50_V4ISH8	0.7246376812
+UniRef50_V4ISH8|g__Bacteroides	0.7246376812
+UniRef50_R5NGW5: Hydrolase carbon-nitrogen family	0.7199424046
+UniRef50_R5NGW5: Hydrolase carbon-nitrogen family|g__Bacteroides	0.7199424046
+UniRef50_B2RH83: Glycine--tRNA ligase	0.7183908046
+UniRef50_B2RH83: Glycine--tRNA ligase|g__Bacteroides	0.7183908046
+UniRef50_D6CWY9: Beta-xylosidase	0.7183908046
+UniRef50_D6CWY9: Beta-xylosidase|g__Bacteroides	0.7183908046
+UniRef50_Q08408: Sensor protein RprX	0.7183908046
+UniRef50_Q08408: Sensor protein RprX|g__Bacteroides	0.7183908046
+UniRef50_R7KSU0	0.7183908046
+UniRef50_R7KSU0|g__Bacteroides	0.7183908046
+UniRef50_R6X4P3	0.7137758744
+UniRef50_R6X4P3|g__Bacteroides	0.7137758744
+UniRef50_R6KNY1	0.7132667618
+UniRef50_R6KNY1|g__Bacteroides	0.7132667618
+UniRef50_R7NW91	0.7122507123
+UniRef50_R7NW91|g__Bacteroides	0.7122507123
+UniRef50_R6TBS5	0.7107320540
+UniRef50_R6TBS5|g__Bacteroides	0.710732054
+UniRef50_R6RRB5	0.7093241623
+UniRef50_R6RRB5|g__Bacteroides	0.7093241623
+UniRef50_R7NXF1: Beta-hexosaminidase	0.7092198582
+UniRef50_R7NXF1: Beta-hexosaminidase|g__Bacteroides	0.7092198582
+UniRef50_Q64YL3	0.7077140835
+UniRef50_Q64YL3|g__Bacteroides	0.7077140835
+UniRef50_R5AL42	0.7077140835
+UniRef50_R5AL42|g__Bacteroides	0.7077140835
+UniRef50_R5LZJ6	0.7077140835
+UniRef50_R5LZJ6|g__Bacteroides	0.7077140835
+UniRef50_R6UUT6: Ferredoxin-type protein	0.7062146893
+UniRef50_R6UUT6: Ferredoxin-type protein|g__Bacteroides	0.7062146893
+UniRef50_A0A016KJM6: Type I restriction modification DNA specificity domain protein	0.7032348805
+UniRef50_A0A016KJM6: Type I restriction modification DNA specificity domain protein|g__Bacteroides	0.7032348805
+UniRef50_F9ZBC6: Transposase	0.7032348805
+UniRef50_F9ZBC6: Transposase|g__Bacteroides	0.7032348805
+UniRef50_Q8A348: Arylsulfatase (Aryl-sulfate sulphohydrolase)	0.7032348805
+UniRef50_Q8A348: Arylsulfatase (Aryl-sulfate sulphohydrolase)|g__Bacteroides	0.7032348805
+UniRef50_R6JLJ9: O-Glycosyl hydrolase family 30	0.7032348805
+UniRef50_R6JLJ9: O-Glycosyl hydrolase family 30|g__Bacteroides	0.7032348805
+UniRef50_I2EPJ9: Peptide chain release factor 3	0.7017543860
+UniRef50_I2EPJ9: Peptide chain release factor 3|g__Bacteroides	0.701754386
+UniRef50_R5JR86	0.7017543860
+UniRef50_R5JR86|g__Bacteroides	0.701754386
+UniRef50_R6CDM8: Type I phosphodiesterase / nucleotide pyrophosphatase	0.7017543860
+UniRef50_R6CDM8: Type I phosphodiesterase / nucleotide pyrophosphatase|g__Bacteroides	0.701754386
+UniRef50_R6L771: Conserved domain protein	0.7017543860
+UniRef50_R6L771: Conserved domain protein|g__Bacteroides	0.701754386
+UniRef50_R7DI90: Rne/Rng family ribonuclease	0.7017543860
+UniRef50_R7DI90: Rne/Rng family ribonuclease|g__Bacteroides	0.701754386
+UniRef50_R7EFC2	0.7017543860
+UniRef50_R7EFC2|g__Bacteroides	0.701754386
+UniRef50_Q8AB43: SusC homolog	0.7003758868
+UniRef50_Q8AB43: SusC homolog|g__Bacteroides	0.7003758868
+UniRef50_R7KLE0	0.7002801120
+UniRef50_R7KLE0|g__Bacteroides	0.700280112
+UniRef50_R5NZJ0: Export membrane protein SecD	0.6995452956
+UniRef50_R5NZJ0: Export membrane protein SecD|g__Bacteroides	0.6995452956
+UniRef50_Q8A8X8: SusD homolog	0.6973500697
+UniRef50_Q8A8X8: SusD homolog|g__Bacteroides	0.6973500697
+UniRef50_R5CQ73: RND transporter HAE1/HME family permease protein	0.6937218176
+UniRef50_R5CQ73: RND transporter HAE1/HME family permease protein|g__Bacteroides	0.6937218176
+UniRef50_R6S9D4: Indolepyruvate oxidoreductase subunit IorA	0.6930006930
+UniRef50_R6S9D4: Indolepyruvate oxidoreductase subunit IorA|g__Bacteroides	0.693000693
+UniRef50_R6DQP6	0.6915629322
+UniRef50_R6DQP6|g__Bacteroides	0.6915629322
+UniRef50_R6VM63: SusD homolog	0.6915629322
+UniRef50_R6VM63: SusD homolog|g__Bacteroides	0.6915629322
+UniRef50_R6YXC4: PSP1 C-terminal domain protein	0.6915629322
+UniRef50_R6YXC4: PSP1 C-terminal domain protein|g__Bacteroides	0.6915629322
+UniRef50_I3YIX4	0.6910850035
+UniRef50_I3YIX4|g__Bacteroides	0.6910850035
+UniRef50_R6LNW7: SusD family protein	0.6901311249
+UniRef50_R6LNW7: SusD family protein|g__Bacteroides	0.6901311249
+UniRef50_R7KS33	0.6872852234
+UniRef50_R7KS33|g__Bacteroides	0.6872852234
+UniRef50_R5RWB9	0.6858710562
+UniRef50_R5RWB9|g__Bacteroides	0.6858710562
+UniRef50_R7DH85	0.6858710562
+UniRef50_R7DH85|g__Bacteroides	0.6858710562
+UniRef50_E6SRW3: Beta-N-acetylhexosaminidase	0.6844626968
+UniRef50_E6SRW3: Beta-N-acetylhexosaminidase|g__Bacteroides	0.6844626968
+UniRef50_Q8A0F6: NADH-quinone oxidoreductase subunit C/D	0.6844626968
+UniRef50_Q8A0F6: NADH-quinone oxidoreductase subunit C/D|g__Bacteroides	0.6844626968
+UniRef50_Q8A1R5	0.6844626968
+UniRef50_Q8A1R5|g__Bacteroides	0.6844626968
+UniRef50_R6LLK0	0.6844626968
+UniRef50_R6LLK0|g__Bacteroides	0.6844626968
+UniRef50_Q8UEY5: CTP synthase	0.6830601093
+UniRef50_Q8UEY5: CTP synthase|g__Bacteroides	0.6830601093
+UniRef50_R7CUF7	0.6830601093
+UniRef50_R7CUF7|g__Bacteroides	0.6830601093
+UniRef50_Q89ZV4: SusC homolog	0.6802721088
+UniRef50_Q89ZV4: SusC homolog|g__Bacteroides	0.6802721088
+UniRef50_R6DIC5	0.6775067751
+UniRef50_R6DIC5|g__Bacteroides	0.6775067751
+UniRef50_R6DAL3	0.6761325220
+UniRef50_R6DAL3|g__Bacteroides	0.676132522
+UniRef50_P31206: Sialidase	0.6734006734
+UniRef50_P31206: Sialidase|g__Bacteroides	0.6734006734
+UniRef50_R5AW16: Hydrophobe/amphiphile efflux-1 (HAE1) family RND transporter	0.6734006734
+UniRef50_R5AW16: Hydrophobe/amphiphile efflux-1 (HAE1) family RND transporter|g__Bacteroides	0.6734006734
+UniRef50_R6XVC7: SusC/RagA family TonB-linked outer membrane protein	0.6734006734
+UniRef50_R6XVC7: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.6734006734
+UniRef50_G8UMR7: Prevent-host-death family protein	0.6720430108
+UniRef50_G8UMR7: Prevent-host-death family protein|g__Bacteroides	0.6720430108
+UniRef50_R5PJX9	0.6720430108
+UniRef50_R5PJX9|g__Bacteroides	0.6720430108
+UniRef50_A0A015TE87: TonB-linked outer membrane , SusC/RagA family protein (Fragment)	0.6713662303
+UniRef50_A0A015TE87: TonB-linked outer membrane , SusC/RagA family protein (Fragment)|g__Bacteroides	0.6713662303
+UniRef50_R7P910: Heavy metal efflux pump CzcA family	0.6713662303
+UniRef50_R7P910: Heavy metal efflux pump CzcA family|g__Bacteroides	0.6713662303
+UniRef50_R5CDQ7	0.6706908115
+UniRef50_R5CDQ7|g__Bacteroides	0.6706908115
+UniRef50_R6JBQ0	0.6700167504
+UniRef50_R6JBQ0|g__Bacteroides	0.6700167504
+UniRef50_R5C9I8: Pseudouridine synthase	0.6693440428
+UniRef50_R5C9I8: Pseudouridine synthase|g__Bacteroides	0.6693440428
+UniRef50_R6VRL5	0.6693440428
+UniRef50_R6VRL5|g__Bacteroides	0.6693440428
+UniRef50_E1WVX1	0.6673340007
+UniRef50_E1WVX1|g__Bacteroides	0.6673340007
+UniRef50_Q8A432	0.6666666667
+UniRef50_Q8A432|g__Bacteroides	0.6666666667
+UniRef50_R6KQB3	0.6653359947
+UniRef50_R6KQB3|g__Bacteroides	0.6653359947
+UniRef50_R5RRH8	0.6652306974
+UniRef50_R5RRH8|g__Bacteroides	0.6652306974
+UniRef50_R7E8U3: Heavy metal efflux pump CzcA family	0.6646726487
+UniRef50_R7E8U3: Heavy metal efflux pump CzcA family|g__Bacteroides	0.6646726487
+UniRef50_F4BY74: Acyl-coenzyme A synthetase	0.6640106242
+UniRef50_F4BY74: Acyl-coenzyme A synthetase|g__Bacteroides	0.6640106242
+UniRef50_Q8A5X9: SusC homolog	0.6640106242
+UniRef50_Q8A5X9: SusC homolog|g__Bacteroides	0.6640106242
+UniRef50_A6KZP1: Flotillin-like protein	0.6626905235
+UniRef50_A6KZP1: Flotillin-like protein|g__Bacteroides	0.6626905235
+UniRef50_F4L7M9: RNA-directed DNA polymerase (Reverse transcriptase)	0.6626905235
+UniRef50_F4L7M9: RNA-directed DNA polymerase (Reverse transcriptase)|g__Bacteroides	0.6626905235
+UniRef50_F9CZX7: DNA repair protein RecN	0.6613756614
+UniRef50_F9CZX7: DNA repair protein RecN|g__Bacteroides	0.6613756614
+UniRef50_U5Q6L5: RagB/SusD Domain-Containing Protein	0.6613756614
+UniRef50_U5Q6L5: RagB/SusD Domain-Containing Protein|g__Bacteroides	0.6613756614
+UniRef50_R5CWL9: Phosphoribulokinase	0.6561679790
+UniRef50_R5CWL9: Phosphoribulokinase|g__Bacteroides	0.656167979
+UniRef50_Q5L883: Glutamate--tRNA ligase	0.6557377049
+UniRef50_Q5L883: Glutamate--tRNA ligase|g__Bacteroides	0.6557377049
+UniRef50_B7FT50: Asparagine synthetase	0.6535947712
+UniRef50_B7FT50: Asparagine synthetase|g__Bacteroides	0.6535947712
+UniRef50_P9WQK2	0.6497725796
+UniRef50_P9WQK2|g__Bacteroides	0.6497725796
+UniRef50_D5BAW2: Sodium:solute symporter family protein	0.6472491909
+UniRef50_D5BAW2: Sodium:solute symporter family protein|g__Bacteroides	0.6472491909
+UniRef50_R5JP66	0.6472491909
+UniRef50_R5JP66|g__Bacteroides	0.6472491909
+UniRef50_R5VIF5	0.6459948320
+UniRef50_R5VIF5|g__Bacteroides	0.645994832
+UniRef50_R6FM99	0.6459948320
+UniRef50_R6FM99|g__Bacteroides	0.645994832
+UniRef50_R7ECP0	0.6459948320
+UniRef50_R7ECP0|g__Bacteroides	0.645994832
+UniRef50_Q8A1T8: TPR-repeat-containing protein	0.6447453256
+UniRef50_Q8A1T8: TPR-repeat-containing protein|g__Bacteroides	0.6447453256
+UniRef50_Q8A353: SusD homolog	0.6447453256
+UniRef50_Q8A353: SusD homolog|g__Bacteroides	0.6447453256
+UniRef50_R6DG46: Arylsulfatase	0.6435006435
+UniRef50_R6DG46: Arylsulfatase|g__Bacteroides	0.6435006435
+UniRef50_A5FIF9: Potassium-transporting ATPase A chain	0.6422607579
+UniRef50_A5FIF9: Potassium-transporting ATPase A chain|g__Bacteroides	0.6422607579
+UniRef50_Q8A2Z5: Alpha-1,3-galactosidase A	0.6422607579
+UniRef50_Q8A2Z5: Alpha-1,3-galactosidase A|g__Bacteroides	0.6422607579
+UniRef50_R7KKH7	0.6410256410
+UniRef50_R7KKH7|g__Bacteroides	0.641025641
+UniRef50_Q8A6V1: Galactose-binding-like protein	0.6397952655
+UniRef50_Q8A6V1: Galactose-binding-like protein|g__Bacteroides	0.6397952655
+UniRef50_R6L9N3: SusD family protein	0.6397952655
+UniRef50_R6L9N3: SusD family protein|g__Bacteroides	0.6397952655
+UniRef50_R6LHG5: SusD family protein	0.6397952655
+UniRef50_R6LHG5: SusD family protein|g__Bacteroides	0.6397952655
+UniRef50_R7EQT9: Single-stranded-DNA-specific exonuclease RecJ	0.6373486297
+UniRef50_R7EQT9: Single-stranded-DNA-specific exonuclease RecJ|g__Bacteroides	0.6373486297
+UniRef50_Q73RR6: Formate--tetrahydrofolate ligase	0.6361323155
+UniRef50_Q73RR6: Formate--tetrahydrofolate ligase|g__Bacteroides	0.6361323155
+UniRef50_F0R157: Xenobiotic-transporting ATPase	0.6325110689
+UniRef50_F0R157: Xenobiotic-transporting ATPase|g__Bacteroides	0.6325110689
+UniRef50_D6D7U9: SusD family	0.6313131313
+UniRef50_D6D7U9: SusD family|g__Bacteroides	0.6313131313
+UniRef50_R6E831: TPR-repeat-containing protein	0.6301197227
+UniRef50_R6E831: TPR-repeat-containing protein|g__Bacteroides	0.6301197227
+UniRef50_A6L3W6	0.6289308176
+UniRef50_A6L3W6|g__Bacteroides	0.6289308176
+UniRef50_R7JAP3: Glutaminyl-tRNA synthetase	0.6289308176
+UniRef50_R7JAP3: Glutaminyl-tRNA synthetase|g__Bacteroides	0.6289308176
+UniRef50_R6Y1L3: Outer membrane receptor proteins mostly Fe transport	0.6283380459
+UniRef50_R6Y1L3: Outer membrane receptor proteins mostly Fe transport|g__Bacteroides	0.6283380459
+UniRef50_B0NVE5	0.6265664160
+UniRef50_B0NVE5|g__Bacteroides	0.626566416
+UniRef50_R5J4A1	0.6265664160
+UniRef50_R5J4A1|g__Bacteroides	0.626566416
+UniRef50_R7KFK3	0.6265664160
+UniRef50_R7KFK3|g__Bacteroides	0.626566416
+UniRef50_R6JFJ8	0.6230529595
+UniRef50_R6JFJ8|g__Bacteroides	0.6230529595
+UniRef50_Q8A5P2: SusC homolog	0.6224712107
+UniRef50_Q8A5P2: SusC homolog|g__Bacteroides	0.6224712107
+UniRef50_B2GCF9: 1-deoxy-D-xylulose-5-phosphate synthase	0.6218905473
+UniRef50_B2GCF9: 1-deoxy-D-xylulose-5-phosphate synthase|g__Bacteroides	0.6218905473
+UniRef50_I4BA63: H+transporting two-sector ATPase alpha/beta subunit central region	0.6218905473
+UniRef50_I4BA63: H+transporting two-sector ATPase alpha/beta subunit central region|g__Bacteroides	0.6218905473
+UniRef50_Q2S158: Aspartate--tRNA(Asp/Asn) ligase	0.6218905473
+UniRef50_Q2S158: Aspartate--tRNA(Asp/Asn) ligase|g__Bacteroides	0.6218905473
+UniRef50_R5N9P5	0.6207324643
+UniRef50_R5N9P5|g__Bacteroides	0.6207324643
+UniRef50_R5UDW9	0.6207324643
+UniRef50_R5UDW9|g__Bacteroides	0.6207324643
+UniRef50_U2JMV5: Beta-galactosidase family protein	0.6201550388
+UniRef50_U2JMV5: Beta-galactosidase family protein|g__Bacteroides	0.6201550388
+UniRef50_R7NX49: LysM-repeat domain-containing protein	0.6184291899
+UniRef50_R7NX49: LysM-repeat domain-containing protein|g__Bacteroides	0.6184291899
+UniRef50_E5WVI9	0.6172839506
+UniRef50_E5WVI9|g__Bacteroides	0.6172839506
+UniRef50_R5JC37	0.6172839506
+UniRef50_R5JC37|g__Bacteroides	0.6172839506
+UniRef50_R5UPV5: SusC/RagA family TonB-linked outer membrane protein	0.6150061501
+UniRef50_R5UPV5: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.6150061501
+UniRef50_F0R821: RagB/SusD domain-containing protein	0.6105006105
+UniRef50_F0R821: RagB/SusD domain-containing protein|g__Bacteroides	0.6105006105
+UniRef50_Q8A1C5	0.6105006105
+UniRef50_Q8A1C5|g__Bacteroides	0.6105006105
+UniRef50_R7H2N2: Chloride transporter ClC family	0.6093845216
+UniRef50_R7H2N2: Chloride transporter ClC family|g__Bacteroides	0.6093845216
+UniRef50_A6KZA8: Arginine--tRNA ligase	0.6082725061
+UniRef50_A6KZA8: Arginine--tRNA ligase|g__Bacteroides	0.6082725061
+UniRef50_E4T141: SSU ribosomal protein S1P	0.6082725061
+UniRef50_E4T141: SSU ribosomal protein S1P|g__Bacteroides	0.6082725061
+UniRef50_F9D155: M24 family peptidase	0.6082725061
+UniRef50_F9D155: M24 family peptidase|g__Bacteroides	0.6082725061
+UniRef50_R6JQG9: TonB-dependent receptor plug domain protein	0.6077180188
+UniRef50_R6JQG9: TonB-dependent receptor plug domain protein|g__Bacteroides	0.6077180188
+UniRef50_Q8A796	0.6075334143
+UniRef50_Q8A796|g__Bacteroides	0.6075334143
+UniRef50_Q89ZE6	0.6060606061
+UniRef50_Q89ZE6|g__Bacteroides	0.6060606061
+UniRef50_R5J064	0.6060606061
+UniRef50_R5J064|g__Bacteroides	0.6060606061
+UniRef50_R7A898: SusC/RagA family TonB-linked outer membrane protein	0.6055101423
+UniRef50_R7A898: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.6055101423
+UniRef50_Q8A4S4: Alpha-rhamnosidase	0.6044122091
+UniRef50_Q8A4S4: Alpha-rhamnosidase|g__Bacteroides	0.6044122091
+UniRef50_Q7MVU9: UPF0313 protein PG_0934	0.6038647343
+UniRef50_Q7MVU9: UPF0313 protein PG_0934|g__Bacteroides	0.6038647343
+UniRef50_R6XS51	0.6038647343
+UniRef50_R6XS51|g__Bacteroides	0.6038647343
+UniRef50_R6B7K2	0.6027727547
+UniRef50_R6B7K2|g__Bacteroides	0.6027727547
+UniRef50_Q8A9K9: Isoleucine--tRNA ligase	0.5989817311
+UniRef50_Q8A9K9: Isoleucine--tRNA ligase|g__Bacteroides	0.5989817311
+UniRef50_W4PA70: Isoleucyl-tRNA synthetase	0.5989817311
+UniRef50_W4PA70: Isoleucyl-tRNA synthetase|g__Bacteroides	0.5989817311
+UniRef50_A6L334: K+ uptake protein	0.5952380952
+UniRef50_A6L334: K+ uptake protein|g__Bacteroides	0.5952380952
+UniRef50_Q8A0X3: TonB	0.5952380952
+UniRef50_Q8A0X3: TonB|g__Bacteroides	0.5952380952
+UniRef50_R5BDA2	0.5952380952
+UniRef50_R5BDA2|g__Bacteroides	0.5952380952
+UniRef50_R5M6Z7: Peptidase U32 family	0.5952380952
+UniRef50_R5M6Z7: Peptidase U32 family|g__Bacteroides	0.5952380952
+UniRef50_D6CWL4: Beta-fructosidases (Levanase/invertase)	0.5941770648
+UniRef50_D6CWL4: Beta-fructosidases (Levanase/invertase)|g__Bacteroides	0.5941770648
+UniRef50_R6VZJ1: Cna protein B-type domain protein	0.5910165485
+UniRef50_R6VZJ1: Cna protein B-type domain protein|g__Bacteroides	0.5910165485
+UniRef50_R7E2E7	0.5910165485
+UniRef50_R7E2E7|g__Bacteroides	0.5910165485
+UniRef50_Q89ZX0: Alpha-1,3-galactosidase B	0.5889281508
+UniRef50_Q89ZX0: Alpha-1,3-galactosidase B|g__Bacteroides	0.5889281508
+UniRef50_D6CY89: SusD family	0.5858230814
+UniRef50_D6CY89: SusD family|g__Bacteroides	0.5858230814
+UniRef50_Q8A0D6: SusD homolog	0.5858230814
+UniRef50_Q8A0D6: SusD homolog|g__Bacteroides	0.5858230814
+UniRef50_Q8AB57: UPF0313 protein BT_0254	0.5837711617
+UniRef50_Q8AB57: UPF0313 protein BT_0254|g__Bacteroides	0.5837711617
+UniRef50_R7EYT6: Penicillin-binding protein 2	0.5827505828
+UniRef50_R7EYT6: Penicillin-binding protein 2|g__Bacteroides	0.5827505828
+UniRef50_R5P5X8: SusC/RagA family TonB-linked outer membrane protein	0.5822416303
+UniRef50_R5P5X8: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.5822416303
+UniRef50_Q8A3R1: SusD homolog	0.5797101449
+UniRef50_Q8A3R1: SusD homolog|g__Bacteroides	0.5797101449
+UniRef50_R6B5M7: Precorrin-4 C(11)-methyltransferase	0.5787037037
+UniRef50_R6B5M7: Precorrin-4 C(11)-methyltransferase|g__Bacteroides	0.5787037037
+UniRef50_R6V6K6	0.5787037037
+UniRef50_R6V6K6|g__Bacteroides	0.5787037037
+UniRef50_A6L0Y0: Glycoside hydrolase family 32, candidate levanase	0.5777007510
+UniRef50_A6L0Y0: Glycoside hydrolase family 32, candidate levanase|g__Bacteroides	0.577700751
+UniRef50_K4ISX9	0.5757052389
+UniRef50_K4ISX9|g__Bacteroides	0.5757052389
+UniRef50_R5UAT7: Glycosyl hydrolase family 16	0.5727376861
+UniRef50_R5UAT7: Glycosyl hydrolase family 16|g__Bacteroides	0.5727376861
+UniRef50_Q59676: Methylmalonyl-CoA mutase small subunit	0.5717552887
+UniRef50_Q59676: Methylmalonyl-CoA mutase small subunit|g__Bacteroides	0.5717552887
+UniRef50_Q5LH44: 1-deoxy-D-xylulose-5-phosphate synthase	0.5688282139
+UniRef50_Q5LH44: 1-deoxy-D-xylulose-5-phosphate synthase|g__Bacteroides	0.5688282139
+UniRef50_I8V7H4	0.5676573772
+UniRef50_I8V7H4|g__Bacteroides	0.5676573772
+UniRef50_E2NFM4: Proton-translocating NADH-quinone oxidoreductase, chain L	0.5668934240
+UniRef50_E2NFM4: Proton-translocating NADH-quinone oxidoreductase, chain L|g__Bacteroides	0.566893424
+UniRef50_A0A015Q9A2	0.5659309564
+UniRef50_A0A015Q9A2|g__Bacteroides	0.5659309564
+UniRef50_R7EC20: Hsp90-like protein	0.5649717514
+UniRef50_R7EC20: Hsp90-like protein|g__Bacteroides	0.5649717514
+UniRef50_R5JSN7	0.5646527386
+UniRef50_R5JSN7|g__Bacteroides	0.5646527386
+UniRef50_Q8A087: SusD homolog	0.5640157924
+UniRef50_Q8A087: SusD homolog|g__Bacteroides	0.5640157924
+UniRef50_R6KUS8: SusD homolog	0.5640157924
+UniRef50_R6KUS8: SusD homolog|g__Bacteroides	0.5640157924
+UniRef50_R5UUD4	0.5630630631
+UniRef50_R5UUD4|g__Bacteroides	0.5630630631
+UniRef50_R5VKI6	0.5630630631
+UniRef50_R5VKI6|g__Bacteroides	0.5630630631
+UniRef50_Q8A1Y8: SusD homolog	0.5621135469
+UniRef50_Q8A1Y8: SusD homolog|g__Bacteroides	0.5621135469
+UniRef50_A6L297	0.5602240896
+UniRef50_A6L297|g__Bacteroides	0.5602240896
+UniRef50_R5JRS8: Hsp90-like protein	0.5602240896
+UniRef50_R5JRS8: Hsp90-like protein|g__Bacteroides	0.5602240896
+UniRef50_G8THU4: Threonine--tRNA ligase	0.5583472920
+UniRef50_G8THU4: Threonine--tRNA ligase|g__Bacteroides	0.558347292
+UniRef50_R6KN74	0.5574136009
+UniRef50_R6KN74|g__Bacteroides	0.5574136009
+UniRef50_D6D2F3: Predicted P-loop ATPase and inactivated derivatives	0.5537098560
+UniRef50_D6D2F3: Predicted P-loop ATPase and inactivated derivatives|g__Bacteroides	0.553709856
+UniRef50_R6J801	0.5518763797
+UniRef50_R6J801|g__Bacteroides	0.5518763797
+UniRef50_U5Q855: DNA gyrase subunit B	0.5518763797
+UniRef50_U5Q855: DNA gyrase subunit B|g__Bacteroides	0.5518763797
+UniRef50_E1WUR9	0.5509641873
+UniRef50_E1WUR9|g__Bacteroides	0.5509641873
+UniRef50_R5JNS6	0.5500550055
+UniRef50_R5JNS6|g__Bacteroides	0.5500550055
+UniRef50_R7KNC4	0.5500550055
+UniRef50_R7KNC4|g__Bacteroides	0.5500550055
+UniRef50_R6LH43	0.5491488193
+UniRef50_R6LH43|g__Bacteroides	0.5491488193
+UniRef50_R7DJ50: DNA polymerase III alpha subunit	0.5473453749
+UniRef50_R7DJ50: DNA polymerase III alpha subunit|g__Bacteroides	0.5473453749
+UniRef50_R5UNH2: Glycosyl hydrolase family 20 catalytic domain protein	0.5446623094
+UniRef50_R5UNH2: Glycosyl hydrolase family 20 catalytic domain protein|g__Bacteroides	0.5446623094
+UniRef50_R5PFV8: Sialic acid-specific 9-O-acetylesterase	0.5437737901
+UniRef50_R5PFV8: Sialic acid-specific 9-O-acetylesterase|g__Bacteroides	0.5437737901
+UniRef50_R6M6L8: Oligopeptide transporter OPT family	0.5437737901
+UniRef50_R6M6L8: Oligopeptide transporter OPT family|g__Bacteroides	0.5437737901
+UniRef50_Q7MW52: Fructose-1,6-bisphosphatase class 3	0.5420054201
+UniRef50_Q7MW52: Fructose-1,6-bisphosphatase class 3|g__Bacteroides	0.5420054201
+UniRef50_Q8A2J2	0.5393743258
+UniRef50_Q8A2J2|g__Bacteroides	0.5393743258
+UniRef50_I9PR43: TonB family domain-containing protein	0.5376344086
+UniRef50_I9PR43: TonB family domain-containing protein|g__Bacteroides	0.5376344086
+UniRef50_Q8A2Z8: SusD homolog	0.5359056806
+UniRef50_Q8A2Z8: SusD homolog|g__Bacteroides	0.5359056806
+UniRef50_R5JBX4	0.5359056806
+UniRef50_R5JBX4|g__Bacteroides	0.5359056806
+UniRef50_C9KZG4	0.5341880342
+UniRef50_C9KZG4|g__Bacteroides	0.5341880342
+UniRef50_R6KML9	0.5299417064
+UniRef50_R6KML9|g__Bacteroides	0.5299417064
+UniRef50_R7DL47: Methionine--tRNA ligase	0.5291005291
+UniRef50_R7DL47: Methionine--tRNA ligase|g__Bacteroides	0.5291005291
+UniRef50_R5U6Y1	0.5282620180
+UniRef50_R5U6Y1|g__Bacteroides	0.528262018
+UniRef50_R7EGT0	0.5274261603
+UniRef50_R7EGT0|g__Bacteroides	0.5274261603
+UniRef50_Q8A2Y8	0.5265929437
+UniRef50_Q8A2Y8|g__Bacteroides	0.5265929437
+UniRef50_Q8A5J3	0.5265929437
+UniRef50_Q8A5J3|g__Bacteroides	0.5265929437
+UniRef50_R5RES4: Beta-galactosidase	0.5265929437
+UniRef50_R5RES4: Beta-galactosidase|g__Bacteroides	0.5265929437
+UniRef50_W4UTT1: Chaperone protein HtpG	0.5265929437
+UniRef50_W4UTT1: Chaperone protein HtpG|g__Bacteroides	0.5265929437
+UniRef50_R5MBV2: ComEC/Rec2-like protein	0.5249343832
+UniRef50_R5MBV2: ComEC/Rec2-like protein|g__Bacteroides	0.5249343832
+UniRef50_R6NQK2: Cyclic nucleotide-binding domain protein	0.5241090147
+UniRef50_R6NQK2: Cyclic nucleotide-binding domain protein|g__Bacteroides	0.5241090147
+UniRef50_Q8A1G3: Alpha-amylase SusG	0.5232862376
+UniRef50_Q8A1G3: Alpha-amylase SusG|g__Bacteroides	0.5232862376
+UniRef50_R6VBD5	0.5228758170
+UniRef50_R6VBD5|g__Bacteroides	0.522875817
+UniRef50_R5SVH9	0.5224660397
+UniRef50_R5SVH9|g__Bacteroides	0.5224660397
+UniRef50_F3ZTW8	0.5175983437
+UniRef50_F3ZTW8|g__Bacteroides	0.5175983437
+UniRef50_R5V0M9	0.5155968033
+UniRef50_R5V0M9|g__Bacteroides	0.5155968033
+UniRef50_R7DUK0: Polyphosphate kinase	0.5151983514
+UniRef50_R7DUK0: Polyphosphate kinase|g__Bacteroides	0.5151983514
+UniRef50_R6V165: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)	0.5144032922
+UniRef50_R6V165: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)|g__Bacteroides	0.5144032922
+UniRef50_W4P8H9: ATP-dependent DNA helicase RecG	0.5136106831
+UniRef50_W4P8H9: ATP-dependent DNA helicase RecG|g__Bacteroides	0.5136106831
+UniRef50_W4P379: Two-component system sensor histidine kinase/response	0.5108556833
+UniRef50_W4P379: Two-component system sensor histidine kinase/response|g__Bacteroides	0.5108556833
+UniRef50_E5X0X2: Translation elongation factor G	0.5081300813
+UniRef50_E5X0X2: Translation elongation factor G|g__Bacteroides	0.5081300813
+UniRef50_R6L5S5: VirE N-terminal domain protein	0.5058168943
+UniRef50_R6L5S5: VirE N-terminal domain protein|g__Bacteroides	0.5058168943
+UniRef50_R7KDZ3: Transcriptional regulator	0.5042864347
+UniRef50_R7KDZ3: Transcriptional regulator|g__Bacteroides	0.5042864347
+UniRef50_R7CYV8	0.5035246727
+UniRef50_R7CYV8|g__Bacteroides	0.5035246727
+UniRef50_A6LD25: ATP-dependent zinc metalloprotease FtsH	0.5027652086
+UniRef50_A6LD25: ATP-dependent zinc metalloprotease FtsH|g__Bacteroides	0.5027652086
+UniRef50_R5RR30	0.5020080321
+UniRef50_R5RR30|g__Bacteroides	0.5020080321
+UniRef50_R5JK30: Competence protein ComEA helix-hairpin-helix repeat region	0.5012531328
+UniRef50_R5JK30: Competence protein ComEA helix-hairpin-helix repeat region|g__Bacteroides	0.5012531328
+UniRef50_Q8A6E8	0.5005005005
+UniRef50_Q8A6E8|g__Bacteroides	0.5005005005
+UniRef50_R6SD13	0.5005005005
+UniRef50_R6SD13|g__Bacteroides	0.5005005005
+UniRef50_A6LGN2: Glycoside hydrolase family 92	0.4990019960
+UniRef50_A6LGN2: Glycoside hydrolase family 92|g__Bacteroides	0.499001996
+UniRef50_R6YNN2	0.4990019960
+UniRef50_R6YNN2|g__Bacteroides	0.499001996
+UniRef50_G8ULE1: TonB-dependent receptor	0.4982561036
+UniRef50_G8ULE1: TonB-dependent receptor|g__Bacteroides	0.4982561036
+UniRef50_R6DCY1: Alpha-galactosidase	0.4982561036
+UniRef50_R6DCY1: Alpha-galactosidase|g__Bacteroides	0.4982561036
+UniRef50_R6W323	0.4982561036
+UniRef50_R6W323|g__Bacteroides	0.4982561036
+UniRef50_A6LH84: Ribonuclease R	0.4975124378
+UniRef50_A6LH84: Ribonuclease R|g__Bacteroides	0.4975124378
+UniRef50_R7E450	0.4975124378
+UniRef50_R7E450|g__Bacteroides	0.4975124378
+UniRef50_R5K992	0.4960317460
+UniRef50_R5K992|g__Bacteroides	0.496031746
+UniRef50_R6EBG9	0.4960317460
+UniRef50_R6EBG9|g__Bacteroides	0.496031746
+UniRef50_F0R6L9	0.4930966469
+UniRef50_F0R6L9|g__Bacteroides	0.4930966469
+UniRef50_Q8A588	0.4930966469
+UniRef50_Q8A588|g__Bacteroides	0.4930966469
+UniRef50_D5BAK3	0.4923682915
+UniRef50_D5BAK3|g__Bacteroides	0.4923682915
+UniRef50_P15623: Glutamine synthetase	0.4901960784
+UniRef50_P15623: Glutamine synthetase|g__Bacteroides	0.4901960784
+UniRef50_R7CUQ8	0.4894762604
+UniRef50_R7CUQ8|g__Bacteroides	0.4894762604
+UniRef50_R5C130	0.4887585533
+UniRef50_R5C130|g__Bacteroides	0.4887585533
+UniRef50_R6TB39: Alpha-N-acetylglucosaminidase	0.4880429478
+UniRef50_R6TB39: Alpha-N-acetylglucosaminidase|g__Bacteroides	0.4880429478
+UniRef50_R5K4X9	0.4873294347
+UniRef50_R5K4X9|g__Bacteroides	0.4873294347
+UniRef50_Q8A294: Putative K(+)-stimulated pyrophosphate-energized sodium pump	0.4866180049
+UniRef50_Q8A294: Putative K(+)-stimulated pyrophosphate-energized sodium pump|g__Bacteroides	0.4866180049
+UniRef50_H1Y2M1: Alpha-1,2-mannosidase	0.4859086492
+UniRef50_H1Y2M1: Alpha-1,2-mannosidase|g__Bacteroides	0.4859086492
+UniRef50_F9D614: Anaerobic ribonucleoside-triphosphate reductase	0.4852013586
+UniRef50_F9D614: Anaerobic ribonucleoside-triphosphate reductase|g__Bacteroides	0.4852013586
+UniRef50_Q89ZI2: O-GlcNAcase BT_4395	0.4844961240
+UniRef50_Q89ZI2: O-GlcNAcase BT_4395|g__Bacteroides	0.484496124
+UniRef50_R6LDE7	0.4830917874
+UniRef50_R6LDE7|g__Bacteroides	0.4830917874
+UniRef50_W4USI9: Na(+)/H(+) antiporter	0.4816955684
+UniRef50_W4USI9: Na(+)/H(+) antiporter|g__Bacteroides	0.4816955684
+UniRef50_Q8A0W2	0.4810004810
+UniRef50_Q8A0W2|g__Bacteroides	0.481000481
+UniRef50_R6T0L9: Formate acetyltransferase	0.4810004810
+UniRef50_R6T0L9: Formate acetyltransferase|g__Bacteroides	0.481000481
+UniRef50_R5JTT4	0.4775549188
+UniRef50_R5JTT4|g__Bacteroides	0.4775549188
+UniRef50_R6L7R7: Phosphate transporter family protein	0.4775549188
+UniRef50_R6L7R7: Phosphate transporter family protein|g__Bacteroides	0.4775549188
+UniRef50_R7IN27: Aconitate hydratase	0.4775549188
+UniRef50_R7IN27: Aconitate hydratase|g__Bacteroides	0.4775549188
+UniRef50_R6KRM0	0.4758505829
+UniRef50_R6KRM0|g__Bacteroides	0.4758505829
+UniRef50_R5S715: Alpha-1 2-mannosidase family protein	0.4734848485
+UniRef50_R5S715: Alpha-1 2-mannosidase family protein|g__Bacteroides	0.4734848485
+UniRef50_R7ESL0	0.4675081814
+UniRef50_R7ESL0|g__Bacteroides	0.4675081814
+UniRef50_W4PK35: NADP-dependent malic enzyme	0.4668534080
+UniRef50_W4PK35: NADP-dependent malic enzyme|g__Bacteroides	0.466853408
+UniRef50_R6LNA6: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein	0.4645760743
+UniRef50_R6LNA6: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein|g__Bacteroides	0.4645760743
+UniRef50_R7JQ95	0.4642525534
+UniRef50_R7JQ95|g__Bacteroides	0.4642525534
+UniRef50_R6ADK9: Peptidase S54 family	0.4616805171
+UniRef50_R6ADK9: Peptidase S54 family|g__Bacteroides	0.4616805171
+UniRef50_D6D3S8: Penicillin-binding protein 1C	0.4610419548
+UniRef50_D6D3S8: Penicillin-binding protein 1C|g__Bacteroides	0.4610419548
+UniRef50_E6SRS8: Beta-N-acetylhexosaminidase	0.4597701149
+UniRef50_E6SRS8: Beta-N-acetylhexosaminidase|g__Bacteroides	0.4597701149
+UniRef50_R6UY01	0.4591368228
+UniRef50_R6UY01|g__Bacteroides	0.4591368228
+UniRef50_R6CFI1	0.4585052728
+UniRef50_R6CFI1|g__Bacteroides	0.4585052728
+UniRef50_C6XZB6: Heparin and heparin-sulfate lyase	0.4566210046
+UniRef50_C6XZB6: Heparin and heparin-sulfate lyase|g__Bacteroides	0.4566210046
+UniRef50_R6E1F6: PAS domain S-box protein	0.4528985507
+UniRef50_R6E1F6: PAS domain S-box protein|g__Bacteroides	0.4528985507
+UniRef50_R6PKV8: ATP-dependent DNA helicase PcrA	0.4510599910
+UniRef50_R6PKV8: ATP-dependent DNA helicase PcrA|g__Bacteroides	0.451059991
+UniRef50_R7EJ31	0.4492362983
+UniRef50_R7EJ31|g__Bacteroides	0.4492362983
+UniRef50_Q89YX8: Chaperone protein dnaK	0.4486316734
+UniRef50_Q89YX8: Chaperone protein dnaK|g__Bacteroides	0.4486316734
+UniRef50_R5CR06: TonB-dependent receptor plug domain protein	0.4480286738
+UniRef50_R5CR06: TonB-dependent receptor plug domain protein|g__Bacteroides	0.4480286738
+UniRef50_A6L0H6	0.4438526409
+UniRef50_A6L0H6|g__Bacteroides	0.4438526409
+UniRef50_R6AYT4	0.4420866490
+UniRef50_R6AYT4|g__Bacteroides	0.442086649
+UniRef50_R5JJP2	0.4411317895
+UniRef50_R5JJP2|g__Bacteroides	0.4411317895
+UniRef50_R6E1E0	0.4374453193
+UniRef50_R6E1E0|g__Bacteroides	0.4374453193
+UniRef50_R6SCN4: Primosomal protein N	0.4334633723
+UniRef50_R6SCN4: Primosomal protein N|g__Bacteroides	0.4334633723
+UniRef50_Q8AA39: Phenylalanine--tRNA ligase beta subunit	0.4323389537
+UniRef50_Q8AA39: Phenylalanine--tRNA ligase beta subunit|g__Bacteroides	0.4323389537
+UniRef50_A6L531: Lon protease	0.4306632214
+UniRef50_A6L531: Lon protease|g__Bacteroides	0.4306632214
+UniRef50_R5V1Q8	0.4306632214
+UniRef50_R5V1Q8|g__Bacteroides	0.4306632214
+UniRef50_R6A6J8	0.4306632214
+UniRef50_R6A6J8|g__Bacteroides	0.4306632214
+UniRef50_R5JCI3	0.4295532646
+UniRef50_R5JCI3|g__Bacteroides	0.4295532646
+UniRef50_Q7MXK3: Pyridine nucleotide-disulphide oxidoreductase family protein	0.4290004290
+UniRef50_Q7MXK3: Pyridine nucleotide-disulphide oxidoreductase family protein|g__Bacteroides	0.429000429
+UniRef50_Q8A5J6: Protein prenyltransferase	0.4290004290
+UniRef50_Q8A5J6: Protein prenyltransferase|g__Bacteroides	0.429000429
+UniRef50_R6LNL6: Heparinase II/III-like protein	0.4246284501
+UniRef50_R6LNL6: Heparinase II/III-like protein|g__Bacteroides	0.4246284501
+UniRef50_W0EY48: Cell division protein FtsK	0.4224757076
+UniRef50_W0EY48: Cell division protein FtsK|g__Bacteroides	0.4224757076
+UniRef50_W4PWJ1: ATP-dependent Clp protease ATP-binding subunit ClpA	0.4208754209
+UniRef50_W4PWJ1: ATP-dependent Clp protease ATP-binding subunit ClpA|g__Bacteroides	0.4208754209
+UniRef50_F3ZRV7: Polysaccharide deacetylase	0.4203446826
+UniRef50_F3ZRV7: Polysaccharide deacetylase|g__Bacteroides	0.4203446826
+UniRef50_R6MGF8: Glycosyl hydrolase family 88	0.4203446826
+UniRef50_R6MGF8: Glycosyl hydrolase family 88|g__Bacteroides	0.4203446826
+UniRef50_A7V674	0.4192872117
+UniRef50_A7V674|g__Bacteroides	0.4192872117
+UniRef50_R6DAL5	0.4187604690
+UniRef50_R6DAL5|g__Bacteroides	0.418760469
+UniRef50_R6V688	0.4171881519
+UniRef50_R6V688|g__Bacteroides	0.4171881519
+UniRef50_Q8A2M3	0.4166666667
+UniRef50_Q8A2M3|g__Bacteroides	0.4166666667
+UniRef50_R7DK62	0.4161464836
+UniRef50_R7DK62|g__Bacteroides	0.4161464836
+UniRef50_E6SRR3: Cobaltochelatase CobN subunit	0.4140786749
+UniRef50_E6SRR3: Cobaltochelatase CobN subunit|g__Bacteroides	0.4140786749
+UniRef50_A6KYY0	0.4125412541
+UniRef50_A6KYY0|g__Bacteroides	0.4125412541
+UniRef50_R6V2H3	0.4125412541
+UniRef50_R6V2H3|g__Bacteroides	0.4125412541
+UniRef50_R6DNC6	0.4120313144
+UniRef50_R6DNC6|g__Bacteroides	0.4120313144
+UniRef50_R6V2A4	0.4100041000
+UniRef50_R6V2A4|g__Bacteroides	0.4100041
+UniRef50_R6USZ4	0.4070004070
+UniRef50_R6USZ4|g__Bacteroides	0.407000407
+UniRef50_R5IDT6: Heparinase II/III-like protein	0.4045307443
+UniRef50_R5IDT6: Heparinase II/III-like protein|g__Bacteroides	0.4045307443
+UniRef50_A6L738	0.4016064257
+UniRef50_A6L738|g__Bacteroides	0.4016064257
+UniRef50_R5TVB0: Outer membrane protein assembly complex YaeT protein	0.4016064257
+UniRef50_R5TVB0: Outer membrane protein assembly complex YaeT protein|g__Bacteroides	0.4016064257
+UniRef50_D6D1X9: TonB-dependent Receptor Plug Domain	0.4011231448
+UniRef50_D6D1X9: TonB-dependent Receptor Plug Domain|g__Bacteroides	0.4011231448
+UniRef50_R6ZUC7	0.3996802558
+UniRef50_R6ZUC7|g__Bacteroides	0.3996802558
+UniRef50_R6FBS9: Valine--tRNA ligase	0.3944773176
+UniRef50_R6FBS9: Valine--tRNA ligase|g__Bacteroides	0.3944773176
+UniRef50_Q8A3A6	0.3940110323
+UniRef50_Q8A3A6|g__Bacteroides	0.3940110323
+UniRef50_F2KVD6: TonB-linked outer membrane protein, SusC/RagA family	0.3926187672
+UniRef50_F2KVD6: TonB-linked outer membrane protein, SusC/RagA family|g__Bacteroides	0.3926187672
+UniRef50_R7KYE3: PAS domain S-box protein	0.3903200625
+UniRef50_R7KYE3: PAS domain S-box protein|g__Bacteroides	0.3903200625
+UniRef50_A6LGN1: Glycoside hydrolase family 78	0.3898635478
+UniRef50_A6LGN1: Glycoside hydrolase family 78|g__Bacteroides	0.3898635478
+UniRef50_A0A016A5N0: Calcineurin-like phosphoesterase family protein	0.3894080997
+UniRef50_A0A016A5N0: Calcineurin-like phosphoesterase family protein|g__Bacteroides	0.3894080997
+UniRef50_R6IPY9	0.3853564547
+UniRef50_R6IPY9|g__Bacteroides	0.3853564547
+UniRef50_I8UZ19	0.3840245776
+UniRef50_I8UZ19|g__Bacteroides	0.3840245776
+UniRef50_R6L8R6	0.3827018752
+UniRef50_R6L8R6|g__Bacteroides	0.3827018752
+UniRef50_F0R2J5: Lipolytic protein G-D-S-L family	0.3809523810
+UniRef50_F0R2J5: Lipolytic protein G-D-S-L family|g__Bacteroides	0.380952381
+UniRef50_R7KFQ3	0.3783579266
+UniRef50_R7KFQ3|g__Bacteroides	0.3783579266
+UniRef50_R6ABH0: Leucine Rich Repeat protein	0.3779289494
+UniRef50_R6ABH0: Leucine Rich Repeat protein|g__Bacteroides	0.3779289494
+UniRef50_UPI000468D7B3: membrane protein	0.3775009438
+UniRef50_UPI000468D7B3: membrane protein|g__Bacteroides	0.3775009438
+UniRef50_B0NVC6	0.3757985720
+UniRef50_B0NVC6|g__Bacteroides	0.375798572
+UniRef50_R6JPJ7: Peptidase M16 inactive domain protein	0.3745318352
+UniRef50_R6JPJ7: Peptidase M16 inactive domain protein|g__Bacteroides	0.3745318352
+UniRef50_R5DGH3	0.3724394786
+UniRef50_R5DGH3|g__Bacteroides	0.3724394786
+UniRef50_C6W4A8: DNA polymerase I	0.3703703704
+UniRef50_C6W4A8: DNA polymerase I|g__Bacteroides	0.3703703704
+UniRef50_D6CWG8: Outer membrane receptor for ferrienterochelin and colicins	0.3687315634
+UniRef50_D6CWG8: Outer membrane receptor for ferrienterochelin and colicins|g__Bacteroides	0.3687315634
+UniRef50_R6JEN9: Outer membrane protein	0.3679175865
+UniRef50_R6JEN9: Outer membrane protein|g__Bacteroides	0.3679175865
+UniRef50_H8KX53: TonB-linked outer membrane protein, SusC/RagA family	0.3663003663
+UniRef50_H8KX53: TonB-linked outer membrane protein, SusC/RagA family|g__Bacteroides	0.3663003663
+UniRef50_R5W6Y4	0.3654970760
+UniRef50_R5W6Y4|g__Bacteroides	0.365497076
+UniRef50_D9RX34: DNA primase small subunit	0.3635041803
+UniRef50_D9RX34: DNA primase small subunit|g__Bacteroides	0.3635041803
+UniRef50_R7DZW3: Chondroitin sulfate ABC lyase	0.3635041803
+UniRef50_R7DZW3: Chondroitin sulfate ABC lyase|g__Bacteroides	0.3635041803
+UniRef50_R7DSH7: Fibronectin type III domain protein	0.3619254434
+UniRef50_R7DSH7: Fibronectin type III domain protein|g__Bacteroides	0.3619254434
+UniRef50_E6SRT3: Alpha-1,2-mannosidase	0.3599712023
+UniRef50_E6SRT3: Alpha-1,2-mannosidase|g__Bacteroides	0.3599712023
+UniRef50_F3PEE8: Fibronectin type III domain protein	0.3595828839
+UniRef50_F3PEE8: Fibronectin type III domain protein|g__Bacteroides	0.3595828839
+UniRef50_R7NUS0: Glycosyl hydrolase family 88	0.3580379520
+UniRef50_R7NUS0: Glycosyl hydrolase family 88|g__Bacteroides	0.358037952
+UniRef50_R6DLA2	0.3572704537
+UniRef50_R6DLA2|g__Bacteroides	0.3572704537
+UniRef50_Q8A069: Beta-galactosidase I	0.3557452864
+UniRef50_Q8A069: Beta-galactosidase I|g__Bacteroides	0.3557452864
+UniRef50_A0A015R3S0: TonB-dependent Receptor Plug domain protein (Fragment)	0.3527336861
+UniRef50_A0A015R3S0: TonB-dependent Receptor Plug domain protein (Fragment)|g__Bacteroides	0.3527336861
+UniRef50_E5CDR5: SusC/RagA family TonB-linked outer membrane protein	0.3483106931
+UniRef50_E5CDR5: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.3483106931
+UniRef50_W4UYD9: RND multidrug efflux transporter	0.3468609088
+UniRef50_W4UYD9: RND multidrug efflux transporter|g__Bacteroides	0.3468609088
+UniRef50_Q89YN9	0.3465003465
+UniRef50_Q89YN9|g__Bacteroides	0.3465003465
+UniRef50_R5TUC7: TonB-linked outer membrane protein SusC/RagA family	0.3415300546
+UniRef50_R5TUC7: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides	0.3415300546
+UniRef50_C7M5I0: TonB-dependent receptor	0.3411804845
+UniRef50_C7M5I0: TonB-dependent receptor|g__Bacteroides	0.3411804845
+UniRef50_J9CMJ3: Chondroitinase (Chondroitin lyase)	0.3408316292
+UniRef50_J9CMJ3: Chondroitinase (Chondroitin lyase)|g__Bacteroides	0.3408316292
+UniRef50_R6JIE4	0.3408316292
+UniRef50_R6JIE4|g__Bacteroides	0.3408316292
+UniRef50_F4C4Q6: TonB-dependent receptor	0.3397893306
+UniRef50_F4C4Q6: TonB-dependent receptor|g__Bacteroides	0.3397893306
+UniRef50_R7KG39	0.3394433130
+UniRef50_R7KG39|g__Bacteroides	0.339443313
+UniRef50_R6XL42: SusC homolog	0.3387533875
+UniRef50_R6XL42: SusC homolog|g__Bacteroides	0.3387533875
+UniRef50_R5JMI4: Hydrophobe/amphiphile efflux-1 family RND transporter	0.3384094755
+UniRef50_R5JMI4: Hydrophobe/amphiphile efflux-1 family RND transporter|g__Bacteroides	0.3384094755
+UniRef50_R6ZCC3	0.3367003367
+UniRef50_R6ZCC3|g__Bacteroides	0.3367003367
+UniRef50_Q8A693	0.3353454058
+UniRef50_Q8A693|g__Bacteroides	0.3353454058
+UniRef50_A0A015MLD6: MMPL family protein (Fragment)	0.3343363424
+UniRef50_A0A015MLD6: MMPL family protein (Fragment)|g__Bacteroides	0.3343363424
+UniRef50_F9Z581: Acriflavin resistance protein	0.3343363424
+UniRef50_F9Z581: Acriflavin resistance protein|g__Bacteroides	0.3343363424
+UniRef50_R6ZZ63	0.3340013360
+UniRef50_R6ZZ63|g__Bacteroides	0.334001336
+UniRef50_Q8A2V4	0.3336670003
+UniRef50_Q8A2V4|g__Bacteroides	0.3336670003
+UniRef50_R6XC24: Outer membrane protein	0.3333333333
+UniRef50_R6XC24: Outer membrane protein|g__Bacteroides	0.3333333333
+UniRef50_Q8A053: SusC homolog	0.3330003330
+UniRef50_Q8A053: SusC homolog|g__Bacteroides	0.333000333
+UniRef50_R6DKH0: SusC/RagA family TonB-linked outer membrane protein	0.3330003330
+UniRef50_R6DKH0: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.333000333
+UniRef50_U2IIX4	0.3293807642
+UniRef50_U2IIX4|g__Bacteroides	0.3293807642
+UniRef50_E1WVX2	0.3280839895
+UniRef50_E1WVX2|g__Bacteroides	0.3280839895
+UniRef50_R6D531	0.3229974160
+UniRef50_R6D531|g__Bacteroides	0.322997416
+UniRef50_Q650E1	0.3220611916
+UniRef50_Q650E1|g__Bacteroides	0.3220611916
+UniRef50_Q8ABT1: SusC homolog	0.3211303789
+UniRef50_Q8ABT1: SusC homolog|g__Bacteroides	0.3211303789
+UniRef50_R5JGD8: SusC/RagA family TonB-linked outer membrane protein	0.3208213025
+UniRef50_R5JGD8: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.3208213025
+UniRef50_R6UZ57: Outer membrane protein	0.3208213025
+UniRef50_R6UZ57: Outer membrane protein|g__Bacteroides	0.3208213025
+UniRef50_Q8A8I2: OmpA-related protein	0.3202049312
+UniRef50_Q8A8I2: OmpA-related protein|g__Bacteroides	0.3202049312
+UniRef50_R5JDF9	0.3192848020
+UniRef50_R5JDF9|g__Bacteroides	0.319284802
+UniRef50_A0LYR8: Protein translocase subunit SecA	0.3177629488
+UniRef50_A0LYR8: Protein translocase subunit SecA|g__Bacteroides	0.3177629488
+UniRef50_Q8A794: SusC homolog	0.3159557662
+UniRef50_Q8A794: SusC homolog|g__Bacteroides	0.3159557662
+UniRef50_W6P1M0: Glycoside hydrolase family 2, sugar binding	0.3156565657
+UniRef50_W6P1M0: Glycoside hydrolase family 2, sugar binding|g__Bacteroides	0.3156565657
+UniRef50_Q64XY7: DNA helicase	0.3100775194
+UniRef50_Q64XY7: DNA helicase|g__Bacteroides	0.3100775194
+UniRef50_R6FCT7: TonB-dependent receptor plug domain protein	0.3095017023
+UniRef50_R6FCT7: TonB-dependent receptor plug domain protein|g__Bacteroides	0.3095017023
+UniRef50_R5V0V4: SusC/RagA family TonB-linked outer membrane protein	0.3089280198
+UniRef50_R5V0V4: SusC/RagA family TonB-linked outer membrane protein|g__Bacteroides	0.3089280198
+UniRef50_B0NLM6: Glycosyl hydrolase family 20, catalytic domain protein	0.3024803388
+UniRef50_B0NLM6: Glycosyl hydrolase family 20, catalytic domain protein|g__Bacteroides	0.3024803388
+UniRef50_F2KX57: Helicase C-terminal domain protein	0.3008423586
+UniRef50_F2KX57: Helicase C-terminal domain protein|g__Bacteroides	0.3008423586
+UniRef50_Q7MUD3: Isoleucine--tRNA ligase	0.2994908655
+UniRef50_Q7MUD3: Isoleucine--tRNA ligase|g__Bacteroides	0.2994908655
+UniRef50_R6KN29	0.2994908655
+UniRef50_R6KN29|g__Bacteroides	0.2994908655
+UniRef50_B0NNP8	0.2992220227
+UniRef50_B0NNP8|g__Bacteroides	0.2992220227
+UniRef50_R6L5I6: TonB-linked outer membrane protein SusC/RagA family	0.2931691586
+UniRef50_R6L5I6: TonB-linked outer membrane protein SusC/RagA family|g__Bacteroides	0.2931691586
+UniRef50_Q8A5P7: Beta-galactosidase	0.2911208151
+UniRef50_Q8A5P7: Beta-galactosidase|g__Bacteroides	0.2911208151
+UniRef50_Q89YI7	0.2841716397
+UniRef50_Q89YI7|g__Bacteroides	0.2841716397
+UniRef50_A0A015PUG3	0.2610284521
+UniRef50_A0A015PUG3|g__Bacteroides	0.2610284521
+UniRef50_Q8A8I4: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)	0.2590002590
+UniRef50_Q8A8I4: Two-component system sensor histidine kinase/response regulator, hybrid (One component system)|g__Bacteroides	0.259000259
+UniRef50_Q8A2V3: Cell well associated RhsD protein	0.2587991718
+UniRef50_Q8A2V3: Cell well associated RhsD protein|g__Bacteroides	0.2587991718
+UniRef50_R5P153: Response regulator receiver domain protein	0.2587991718
+UniRef50_R5P153: Response regulator receiver domain protein|g__Bacteroides	0.2587991718
+UniRef50_R7KML3: Two-component system sensor histidine kinase/response regulator	0.2585983967
+UniRef50_R7KML3: Two-component system sensor histidine kinase/response regulator|g__Bacteroides	0.2585983967
+UniRef50_B0NL59: Putative serine--tRNA ligase domain protein	0.2581977795
+UniRef50_B0NL59: Putative serine--tRNA ligase domain protein|g__Bacteroides	0.2581977795
+UniRef50_R7KUE4	0.2575991757
+UniRef50_R7KUE4|g__Bacteroides	0.2575991757
+UniRef50_Q8A241: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)	0.2572016461
+UniRef50_Q8A241: Two-component system sensor histidine kinase/response regulator, hybrid (One-component system)|g__Bacteroides	0.2572016461
+UniRef50_R6ACZ9: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein	0.2556237219
+UniRef50_R6ACZ9: ATPase/histidine kinase/DNA gyrase B/HSP90 domain protein|g__Bacteroides	0.2556237219
+UniRef50_R5JH28	0.2531004809
+UniRef50_R5JH28|g__Bacteroides	0.2531004809
+UniRef50_R6W605: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)	0.2495009980
+UniRef50_R6W605: Two-component system sensor histidine kinase/response regulator hybrid (One-component system)|g__Bacteroides	0.249500998
+UniRef50_D6D1E3: Signal transduction histidine kinase	0.2411963338
+UniRef50_D6D1E3: Signal transduction histidine kinase|g__Bacteroides	0.2411963338
+UniRef50_R6VIN5: DNA-directed RNA polymerase	0.2411963338
+UniRef50_R6VIN5: DNA-directed RNA polymerase|g__Bacteroides	0.2411963338
+UniRef50_R6JLD1: Two-component system sensor histidine kinase/response regulator hybrid (One component system)	0.2342468962
+UniRef50_R6JLD1: Two-component system sensor histidine kinase/response regulator hybrid (One component system)|g__Bacteroides	0.2342468962
+UniRef50_R6L7N8	0.2302025783
+UniRef50_R6L7N8|g__Bacteroides	0.2302025783
+UniRef50_G8UNW7: ABC transporter, ATP-binding protein	0.2192982456
+UniRef50_G8UNW7: ABC transporter, ATP-binding protein|g__Bacteroides	0.2192982456
+UniRef50_R6D9I7	0.2142245073
+UniRef50_R6D9I7|g__Bacteroides	0.2142245073
+UniRef50_A0A016I611: Prophage LambdaSa1, N-acetylmuramoyl-L-alanine amidase, family 4	0.1902587519
+UniRef50_A0A016I611: Prophage LambdaSa1, N-acetylmuramoyl-L-alanine amidase, family 4|g__Bacteroides	0.1902587519
+UniRef50_R7KMV8: Outer membrane protein	0.1818512457
+UniRef50_R7KMV8: Outer membrane protein|g__Bacteroides	0.1818512457

--- a/humann/tests/functional_tests_tools.py
+++ b/humann/tests/functional_tests_tools.py
@@ -316,3 +316,26 @@ class TestFunctionalHumannTools(unittest.TestCase):
 
         # remove the temp file
         utils.remove_temp_file(new_file)
+
+    def test_genefamilies_genus_level(self):
+        """
+        Test creating a genus level gene families table
+        """
+        
+        # create a temp file
+        file_out, new_file=tempfile.mkstemp(prefix="humann_temp")
+        
+        # run the command
+        utils.run_command([
+            "humann_genefamilies_genus_level",
+            "--input",
+            cfg.genefamilies_genus_level_input,
+            "--output",
+            new_file])
+        
+        # check the output file is as expected
+        # allow for varying precision in the calculations with almost equal
+        self.assertTrue(utils.files_almost_equal(new_file, cfg.genefamilies_genus_level_output))
+
+        # remove the temp file
+        utils.remove_temp_file(new_file)

--- a/humann/tools/genefamilies_genus_level.py
+++ b/humann/tools/genefamilies_genus_level.py
@@ -47,7 +47,7 @@ def create_table(input,output):
                         if all_values:
                             file_handle_write.write(all_values)
                             # write genus values for gene, if present
-                            for gene_taxonomy, values in genus_values.iteritems():
+                            for gene_taxonomy, values in genus_values.items():
                                 file_handle_write.write(TABLE_DELIMITER.join([gene_taxonomy]+[str(x) for x in values])+"\n")
                             genus_values={}
                         all_values=line


### PR DESCRIPTION
Hi,

I was testing `humann_genefamilies_genus_level` command within a Python3 environment and I got an error because of `iteritems` removed in Python3.
I also added a functional test for this command.

I hope the changes will fit.

Bérénice