### PR TITLE
Check t__ only on rows with taxonomy

### DIFF
--- a/humann/search/prescreen.py
+++ b/humann/search/prescreen.py
@@ -88,7 +88,7 @@ def create_custom_database(chocophlan_dir, bug_file):
                 version_found = True
 
             # if we see taxon-level we are done processing
-            if re.search("t__", line):
+            if line.startswith("#") and re.search("t__", line):
                 break
  
             # search for the lines that have the species-level information


### PR DESCRIPTION
So, this is causing HUMAnN to run without prescreening even when passing a MetaPhlAn taxonomic profile just because in the second line of the MetaPhlAn profile that starts with `#` and where the command line is reported, by chance, there could be a `t__`.
Actually, the code from line 89 to line 92 could be removed, as MetaPhlAn 3 will never have `t__` in the output profile.
