### PR TITLE
Add support for a user config file

### DIFF
--- a/humann/config.py
+++ b/humann/config.py
@@ -104,8 +104,9 @@ def log_settings():
 # User config file
 user_edit_config_file="humann.cfg"
 
-full_path_user_edit_config_file=os.path.join(os.path.dirname(os.path.abspath(__file__)),
-    user_edit_config_file)
+full_path_user_edit_config_file=os.getenv('HUMAnN_CONFIG',
+    os.path.join(os.path.dirname(os.path.abspath(__file__)),
+    user_edit_config_file))
 
 def update_user_edit_config_file_single_item(section,name,value):
     """


### PR DESCRIPTION
## Description

If HUMAnN is installed in a directory a user does not have write access to,
this patch allowes the config file to be elsewhere, with the path set in the
environment variable: HUMAnN_CONFIG

for example:

`export HUMAnN_CONFIG="/projects/databases/humann.cfg"`

Copy the humann.cfg from the install tree to the above path,
then (with this environemtn variable set,) alternate locations for
the databases can be configured.
For example:

```
humann_config --update database_folders nucleotide /projects/databases/chocophlan
humann_config --update database_folders protein /projects/databases/uniref
humann_config --update database_folders utility_mapping /projects/databases/utility_mapping
```

Tested with HUMAnN versions 3.6 and 3.9

Tony
