### PR TITLE
Update for MetaPhlAn 4.2 compatability

### DIFF
--- a/humann/search/prescreen.py
+++ b/humann/search/prescreen.py
@@ -51,7 +51,7 @@ def alignment(input):
     # outfile name
     bowtie2_out = utilities.name_temp_file(config.metaphlan_bowtie2_name) 
 
-    args=[input]+opts+["-o",config.profile_file,"--input_type",input_type, "--bowtie2out",bowtie2_out]
+    args=[input]+opts+["-o",config.profile_file,"--input_type",input_type, "--mapout",bowtie2_out]
     
     if config.threads >1:
         args+=["--nproc",config.threads]


### PR DESCRIPTION
## Description

MetaPhlAn version 4.2.x introduced changes to how map files are handled, so '--bowtie2out' arg has been changed to '--mapout'. This patch only modifies the arg for compatibility. Ideally it would be conditional on the version of MetaPhlAn being run.
