### PR TITLE
Fix MetaPhlAn link in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ When using the "--resume" option, the following steps will be bypassed if they h
 
 ### Software ###
 
-1. [MetaPhlAn](https://bitbucket.org/biobakery/metaphlan)
+1. [MetaPhlAn](https://github.com/biobakery/MetaPhlAn)
 2. [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/) (version >= 2.2.9) (automatically installed)
 3. [Diamond](http://ab.inf.uni-tuebingen.de/software/diamond/) (version >= 0.9.24) (automatically installed)
 4. [Python](http://www.python.org/) (version >= 3.7)


### PR DESCRIPTION
We welcome feedback and issue reporting for all bioBakery tools through our [Discourse site](https://forum.biobakery.org/c/pull-request/featurepull-request/). For users that would like to directly contribute to the [tools](https://github.com/biobakery/) we are happy to field PRs to address **bug fixes**. Please note the turn around time on our end might be a bit long to field these but that does not mean we don't value the contribution! We currently **don't** accept PRs to add **new functionality** to tools but we would be happy to receive your feedback on [Discourse](https://forum.biobakery.org/c/pull-request/featurepull-request/).

Also, we will make sure to attribute your contribution in our User’s manual(README.md) and in any associated paper Acknowledgements.


## Description
The MetaPhlAn link incorrectly pointed to bitbucket, updated with github link

## Related Issue
The current link points to a not (no longer ?) existing repository on bitbucket.


## Screenshots (if appropriate):
