### PR TITLE
Parallelize diamond alignment + input decompression, compress intermediates

### DIFF
--- a/humann/search/translated.py
+++ b/humann/search/translated.py
@@ -209,7 +209,7 @@ def diamond_alignment(alignment_file,uniref, unaligned_reads_file_fasta):
             utilities.execute_command(exe, shard_args, [input_database], [], raise_error=True)
             return temp_out + ".gz"  # diamond appends .gz when --compress 1 is used
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=n_shards) as pool:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, n_shards)) as pool:
             gz_out_files=list(pool.map(_align_shard, databases))
 
         # decompress and merge all shards into the final output file

--- a/humann/search/translated.py
+++ b/humann/search/translated.py
@@ -29,6 +29,7 @@ import numbers
 import logging
 import math
 import traceback
+import concurrent.futures
 
 from .. import utilities
 from .. import config
@@ -174,7 +175,7 @@ def diamond_alignment(alignment_file,uniref, unaligned_reads_file_fasta):
     opts=config.diamond_opts
 
     args+=["--query",unaligned_reads_file_fasta,"--evalue",config.evalue_threshold]
-    args+=["--threads",config.threads]
+    # --threads is set per-shard below so the total CPU usage stays within config.threads
 
     message="Running " + exe + " ........"
     logger.info(message)
@@ -182,32 +183,40 @@ def diamond_alignment(alignment_file,uniref, unaligned_reads_file_fasta):
 
     if not bypass:
         args+=opts
-        temp_out_files=[]
-        for database in os.listdir(uniref):          
-            # ignore any files that are not the database files
-            if database.endswith(config.diamond_database_extension):
-                # Provide the database name without the extension
-                input_database=os.path.join(uniref,database)
-                message="Aligning to reference database: " + database
-                logger.info(message)
-                print("\n"+message+"\n")  
-                input_database_extension_removed=re.sub(config.diamond_database_extension
-                    +"$","",input_database)
-                full_args=args+["--db",input_database_extension_removed]
-    
-                # create temp output file
-                temp_out_file=utilities.unnamed_temp_file("diamond_m8_")
-                utilities.remove_file(temp_out_file)
-                
-                temp_out_files.append(temp_out_file)
-    
-                full_args+=["--out",temp_out_file,"--tmpdir",os.path.dirname(temp_out_file)]
-    
-                utilities.execute_command(exe,full_args,[input_database],[])
-        
-        # merge the temp output files
-        utilities.execute_command("cat",temp_out_files,temp_out_files,[alignment_file],
+
+        databases=[db for db in os.listdir(uniref)
+                   if db.endswith(config.diamond_database_extension)]
+        n_shards=len(databases)
+        threads_per_shard=max(1, int(config.threads) // n_shards) if n_shards > 1 else int(config.threads)
+
+        def _align_shard(database):
+            input_database=os.path.join(uniref,database)
+            message="Aligning to reference database: " + database
+            logger.info(message)
+            print("\n"+message+"\n")
+
+            db_stem=re.sub(config.diamond_database_extension+"$","",input_database)
+            temp_out=utilities.unnamed_temp_file("diamond_m8_")
+            utilities.remove_file(temp_out)
+
+            shard_args=list(args)+[
+                "--threads", threads_per_shard,
+                "--db", db_stem,
+                "--out", temp_out,
+                "--tmpdir", os.path.dirname(temp_out),
+                "--compress", "1",
+            ]
+            utilities.execute_command(exe, shard_args, [input_database], [], raise_error=True)
+            return temp_out + ".gz"  # diamond appends .gz when --compress 1 is used
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n_shards) as pool:
+            gz_out_files=list(pool.map(_align_shard, databases))
+
+        # decompress and merge all shards into the final output file
+        utilities.execute_command("zcat", gz_out_files, gz_out_files, [alignment_file],
             alignment_file)
+        for f in gz_out_files:
+            utilities.remove_file(f)
 
     else:
         message="Bypass"

--- a/humann/utilities.py
+++ b/humann/utilities.py
@@ -233,29 +233,48 @@ def gunzip_file(gzip_file):
     """
     Return a new copy of the file that is not gzipped
     The new file will be placed in the unnamed temp folder
+
+    Uses pigz (parallel gzip) for decompression when available, which is
+    substantially faster on multi-core nodes than Python's single-threaded
+    gzip module; falls back to the gzip module otherwise.
     """
-    
+
     message="Decompressing gzipped file ..."
     print(message+"\n")
-    logger.info(message)    
-    
+    logger.info(message)
+
+    # create an unnamed temp file for the decompressed output
+    new_file=unnamed_temp_file()
+
+    # prefer parallel decompression with pigz (or unpigz) if on the PATH
+    pigz_exe=shutil.which("pigz") or shutil.which("unpigz")
+    if pigz_exe:
+        try:
+            threads=str(config.threads) if getattr(config,"threads",0) else "1"
+            with open(new_file,"wb") as file_handle:
+                subprocess.check_call(
+                    [pigz_exe,"-d","-c","-p",threads,gzip_file],
+                    stdout=file_handle)
+            logger.debug("Decompressed input with %s using %s threads", pigz_exe, threads)
+            return new_file
+        except (EnvironmentError, subprocess.CalledProcessError) as e:
+            # fall back to the Python gzip module below
+            logger.debug("pigz decompression failed (%s); falling back to gzip module", e)
+
     try:
         file_handle_gzip=gzip.open(gzip_file,"rt")
-        
-        # create a unnamed temp file
-        new_file=unnamed_temp_file()
-        
+
         # write the gunzipped file
         file_handle=open(new_file,"wt")
         shutil.copyfileobj(file_handle_gzip, file_handle)
-        
+
     except EnvironmentError:
         print("Critical Error: Unable to unzip input file: " + gzip_file)
         new_file=""
     finally:
         file_handle.close()
         file_handle_gzip.close()
-        
+
     return new_file
 
 def double_sort(pathways_dictionary):


### PR DESCRIPTION
## Summary

Two related throughput improvements to HUMAnN's I/O-bound steps:

1. **DIAMOND alignment** (`humann/search/translated.py`): run the per-shard
   diamond alignments concurrently (`ThreadPoolExecutor`, `--threads` split
   evenly across shards), and write each shard's output with `--compress 1`,
   merging the gzipped shards with `zcat`. Falls back cleanly to a single
   shard when the protein DB is not split.

2. **Input decompression** (`humann/utilities.py`): `gunzip_file` previously
   used Python's single-threaded gzip module to expand gzipped input into a
   full plain-text temp copy. Use `pigz`/`unpigz` (`-p config.threads`) when
   available, falling back to the gzip module otherwise — behavior is
   unchanged on systems without pigz.