### PR TITLE
Verify and pin the MetaPhlAn database HUMAnN actually uses

### DIFF
--- a/humann/config.py
+++ b/humann/config.py
@@ -378,6 +378,8 @@ metaphlan_version={
     "column" : 2}
 
 metaphlan_v4_db_version="vOct22_CHOCOPhlAnSGB_202403"
+# the name MetaPhlAn knows this database by, as passed to its --index option
+metaphlan_v4_db_index="mpa_"+metaphlan_v4_db_version
 metaphlan_v4_db_matching_uniref="SGB"
 sgb_to_species_mapping={}
 

--- a/humann/search/prescreen.py
+++ b/humann/search/prescreen.py
@@ -46,7 +46,7 @@ DB_TAG_LIKE = re.compile(r'v[A-Z][a-z]{2}\d{2}_[A-Za-z0-9]+_\d{6}')
 def db_lines(output: str) -> list[str]:
     """Return lines likely mentioning the DB."""
     lines = [ln.strip() for ln in output.splitlines()]
-    hits = [ln for ln in lines if re.search(r'\b(DB|database)\b', ln, re.IGNORECASE)]
+    hits = [ln for ln in lines if re.search(r'\b(DB|databases?)\b', ln, re.IGNORECASE)]
     return hits if hits else lines  # fall back to all lines if no explicit DB line
 
 def parse_db_numbers(lines: Iterable[str]) -> list[str]:
@@ -166,12 +166,27 @@ def verify_metaphlan_db_version(expected_db, exe: str = "metaphlan"):
             print(f"\nVerified MetaPhlAn DB tag: {tag}\n")
             return
 
-    # As a helpful hint, surface any tag-like matches we detected
     found_tags = parse_db_tags(lines)
+
+    # Only MetaPhlAn 4.1.2 and 4.2.4+ report their installed databases; earlier
+    # releases print the version alone. Treating silence as a mismatch would
+    # reject every MetaPhlAn this HUMAnN supports apart from 4.1.2, so warn and
+    # continue instead. The run is still pinned, because alignment() passes
+    # --index and MetaPhlAn fails on its own if that database is missing.
+    if not found_tags:
+        msg = (
+            "This version of MetaPhlAn does not report its installed databases, "
+            f"so the HUMAnN requirement of {allowed_tags} could not be confirmed. "
+            "MetaPhlAn will be asked for this database by name."
+        )
+        logger.warning(msg)
+        print("\nWARNING: " + msg + "\n")
+        return
+
     msg = (
         "ERROR: MetaPhlAn DB version check failed.\n"
         f"Expected one of: {allowed_tags if allowed_tags else '[no tags provided]'}\n"
-        f"Detected tag-like strings: {found_tags if found_tags else '[none]'}\n\n"
+        f"Detected tag-like strings: {found_tags}\n\n"
         f"Full output:\n{version_output}"
     )
     logger.error(msg)
@@ -198,7 +213,14 @@ def alignment(input):
     bowtie2_out = utilities.name_temp_file(config.metaphlan_bowtie2_name) 
 
     args=[input]+opts+["-o",config.profile_file,"--input_type",input_type, "--bowtie2out",bowtie2_out,"--offline"]
-    
+
+    # Pin the database. MetaPhlAn defaults to "--index latest", which under
+    # --offline resolves to whichever database is newest on disk -- not
+    # necessarily the one ChocoPhlAn was built against. Skip if the user named
+    # an index themselves through --metaphlan-options.
+    if not set(["-x","--index"]).intersection(opts):
+        args+=["--index",config.metaphlan_v4_db_index]
+
     if config.threads >1:
         args+=["--nproc",config.threads]
 

--- a/humann/tests/basic_tests_metaphlan_db.py
+++ b/humann/tests/basic_tests_metaphlan_db.py
@@ -1,0 +1,140 @@
+"""
+Tests for MetaPhlAn database selection and verification in humann.search.prescreen
+"""
+
+import unittest
+import logging
+import os
+import shutil
+import tempfile
+
+import cfg
+import utils
+
+from humann import config
+from humann.search import prescreen
+
+
+class TestMetaphlanDatabaseCheck(unittest.TestCase):
+    """
+    Test prescreen.verify_metaphlan_db_version
+    """
+
+    def setUp(self):
+        logging.getLogger("humann.search.prescreen").addHandler(logging.NullHandler())
+        self.tempdir = tempfile.mkdtemp(prefix="humann_mpa_stub_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def stub_metaphlan(self, version_output):
+        """Write an executable standing in for 'metaphlan --version'"""
+
+        path = os.path.join(self.tempdir, "metaphlan_stub")
+        with open(path, "w") as handle:
+            handle.write("#!/bin/sh\ncat <<'EOF'\n" + version_output + "\nEOF\n")
+        os.chmod(path, 0o755)
+        return path
+
+    def test_accepts_the_required_database(self):
+        """The required database is found among the installed databases"""
+
+        exe = self.stub_metaphlan(
+            "MetaPhlAn version 4.2.6 (28 Jul 2026)\n"
+            "Installed databases: mpa_vOct22_CHOCOPhlAnSGB_202403")
+        prescreen.verify_metaphlan_db_version("vOct22_CHOCOPhlAnSGB_202403", exe)
+
+    def test_rejects_a_different_database(self):
+        """A MetaPhlAn reporting only other databases is rejected"""
+
+        exe = self.stub_metaphlan(
+            "MetaPhlAn version 4.2.6 (28 Jul 2026)\n"
+            "Installed databases: mpa_vJan25_CHOCOPhlAnSGB_202503")
+        with self.assertRaises(SystemExit):
+            prescreen.verify_metaphlan_db_version("vOct22_CHOCOPhlAnSGB_202403", exe)
+
+    def test_accepts_metaphlan_that_does_not_report_databases(self):
+        """MetaPhlAn releases that print no database line are not rejected
+
+        Only 4.1.2 and 4.2.4+ list installed databases. On 4.0.x and 4.1.1
+        --version prints the version alone, and treating that as a mismatch
+        rejected every supported MetaPhlAn except 4.1.2.
+        """
+
+        exe = self.stub_metaphlan("MetaPhlAn version 4.1.1 (23 May 2024)")
+        prescreen.verify_metaphlan_db_version("vOct22_CHOCOPhlAnSGB_202403", exe)
+
+    def test_database_line_is_recognised(self):
+        """The installed-databases line is picked out of the version output"""
+
+        lines = prescreen.db_lines(
+            "MetaPhlAn version 4.2.6 (28 Jul 2026)\n"
+            "Installed databases: mpa_vOct22_CHOCOPhlAnSGB_202403")
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].startswith("Installed databases:"))
+
+    def test_missing_metaphlan_is_an_error(self):
+        """A MetaPhlAn that cannot be run is reported rather than ignored"""
+
+        with self.assertRaises(SystemExit):
+            prescreen.verify_metaphlan_db_version(
+                "vOct22_CHOCOPhlAnSGB_202403",
+                os.path.join(self.tempdir, "does_not_exist"))
+
+
+class TestMetaphlanCommandLine(unittest.TestCase):
+    """
+    Test the command line prescreen.alignment builds for MetaPhlAn
+    """
+
+    def setUp(self):
+        logging.getLogger("humann.search.prescreen").addHandler(logging.NullHandler())
+
+        self.tempdir = tempfile.mkdtemp(prefix="humann_mpa_cmd_")
+        config.temp_dir = self.tempdir
+        config.unnamed_temp_dir = self.tempdir
+        config.file_basename = "test"
+        config.threads = 1
+
+        self.saved_opts = config.metaphlan_opts
+        self.captured = []
+        self.saved = (prescreen.verify_metaphlan_db_version,
+                      prescreen.utilities.execute_command)
+        prescreen.verify_metaphlan_db_version = lambda *a, **k: None
+        prescreen.utilities.execute_command = \
+            lambda exe, args, *a, **k: self.captured.append([str(arg) for arg in args])
+
+    def tearDown(self):
+        (prescreen.verify_metaphlan_db_version,
+         prescreen.utilities.execute_command) = self.saved
+        config.metaphlan_opts = self.saved_opts
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def metaphlan_args(self):
+        prescreen.alignment(cfg.demo_fastq)
+        return self.captured[0]
+
+    def test_database_index_is_pinned(self):
+        """The database HUMAnN verified is the one MetaPhlAn is asked for"""
+
+        args = self.metaphlan_args()
+        self.assertIn("--index", args)
+        self.assertIn(config.metaphlan_v4_db_index, args)
+
+    def test_pinned_index_carries_the_mpa_prefix(self):
+        """MetaPhlAn resolves --index straight to a filename, so mpa_ is required"""
+
+        self.assertEqual(config.metaphlan_v4_db_index,
+                         "mpa_" + config.metaphlan_v4_db_version)
+
+    def test_user_supplied_index_is_not_overridden(self):
+        """An index given through --metaphlan-options wins"""
+
+        config.metaphlan_opts = ["-t", "rel_ab_w_read_stats", "-x", "mpa_custom"]
+        args = self.metaphlan_args()
+        self.assertEqual(args.count("-x") + args.count("--index"), 1)
+        self.assertNotIn(config.metaphlan_v4_db_index, args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Two problems with the MetaPhlAn database check added in #70, both of which cause HUMAnN to run against the wrong database or refuse to run at all.

### The check rejects almost every supported MetaPhlAn

`setup.py` permits `metaphlan>=4.0.0,<=4.1.2`, but only 4.1.2 and 4.2.4+ print an `Installed databases:` line. On 4.0.x and 4.1.1 `metaphlan --version` prints the version alone, so the expected tag is never found and the run exits — even against a correctly installed `vOct22_CHOCOPhlAnSGB_202403`.

Reproduced with a stub standing in for MetaPhlAn 4.1.1:

```
$ printf '#!/bin/sh\necho "MetaPhlAn version 4.1.1 (23 May 2024)"\n' > mpa && chmod +x mpa
$ python -c "from humann.search import prescreen; \
    prescreen.verify_metaphlan_db_version('vOct22_CHOCOPhlAnSGB_202403','./mpa')"
ERROR: MetaPhlAn DB version check failed.
Expected one of: ['vOct22_CHOCOPhlAnSGB_202403']
Detected tag-like strings: [none]
```

Silence about installed databases is now a warning. A database that *is* reported and does not match is still fatal.

### The check verifies a database that need not be the one used

MetaPhlAn 4.2 lists *every* installed database, and HUMAnN never passed `--index`, so MetaPhlAn fell back to `--index latest` — which under `--offline` resolves to whichever database is newest on disk. `mpa_latest` currently points at `mpa_vJan26_CHOCOPhlAnSGB_202605`, so a user with both vJan26 and the required vOct22 installed passes the check and then profiles against vJan26, with no indication anything is wrong.

`alignment()` now names the database explicitly, unless the user chose one through `--metaphlan-options`. MetaPhlAn resolves `--index` straight to a filename (`{index}.pkl`, `{index}*.bt2l`), so it needs the `mpa_` prefix that `metaphlan_v4_db_version` lacks; `config.metaphlan_v4_db_index` supplies it.

Also fixes the DB-line regex, which did not match the plural in "Installed databases:" and so worked only through its fall-back-to-all-lines branch.

## Tests

New `humann/tests/basic_tests_metaphlan_db.py`, 8 tests, no MetaPhlAn or databases required — `metaphlan --version` is stubbed with a shell script. Covers acceptance, rejection, the no-database-line case, `--index` pinning, the `mpa_` prefix, and not overriding a user-supplied index.

`humann_test.py` picks it up automatically via the `basic_tests_*.py` pattern. Full basic suite: 121 tests, passing.

## Note

This does not make HUMAnN work with MetaPhlAn 4.2 — `--bowtie2out` still needs the rename in #67, and vJan25/vJan26 need a ChocoPhlAn rebuild. It makes the existing check do what it says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)