### PR TITLE
Allow overriding the MetaPhlAn version pin during install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,7 @@ When using the "--resume" option, the following steps will be bypassed if they h
 
 ### Software ###
 
-1. [MetaPhlAn](https://github.com/biobakery/MetaPhlAn)
+1. [MetaPhlAn](https://github.com/biobakery/MetaPhlAn) (version >= 4.0.0, <= 4.1.2)
 2. [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/) (version >= 2.2.9) (automatically installed)
 3. [Diamond](http://ab.inf.uni-tuebingen.de/software/diamond/) (version >= 0.9.24) (automatically installed)
 4. [Python](http://www.python.org/) (version >= 3.7)
@@ -211,6 +211,12 @@ When using the "--resume" option, the following steps will be bypassed if they h
 6. [Xipe](https://edwards.sdsu.edu/cgi-bin/xipe.cgi) (optional / included)
 7. [SAMtools](http://samtools.sourceforge.net/) (only required if bam input files are provided)
 8. [Biom-format](http://biom-format.org/) (only required if input or output files are in biom format)
+
+The MetaPhlAn range is enforced during install. MetaPhlAn 4.2 and later changed
+their command line and default database and are not yet supported. To install
+against an unsupported MetaPhlAn anyway, for example to test compatibility with
+a newer release, set `HUMANN_ALLOW_UNSUPPORTED_METAPHLAN=1`. HUMAnN is not
+expected to work in that configuration.
 
 Please install the required software in a location in your `$PATH` or provide the location with an optional argument to HUMAnN 3.0. 
 For example, the location of the Bowtie2 install ($BOWTIE2_DIR) can be provided with "--bowtie2 $BOWTIE2_DIR".

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,10 @@ except Exception:
 # ---- MetaPhlAn version requirement ----
 REQUIRED_METAPHLAN_SPEC = SpecifierSet(">=4.0.0,<=4.1.2")
 REQUIRED_METAPHLAN_PIN = "metaphlan>=4.0.0,<=4.1.2"
+# Set to install against a MetaPhlAn outside the supported range. Intended for
+# testing HUMAnN against newer MetaPhlAn releases, which is otherwise only
+# possible by editing this file.
+OVERRIDE_ENV_VAR = "HUMANN_ALLOW_UNSUPPORTED_METAPHLAN"
 
 def check_metaphlan_version():
     """
@@ -110,21 +114,39 @@ def check_metaphlan_version():
     """
     installed = _get_dist_version("metaphlan")
     if installed is None:
-        # Not installed yet; pip resolver should install it via install_requires.
+        # MetaPhlAn is not declared as a dependency, so it may legitimately be
+        # absent here and installed separately (conda, module system, manually).
         return
+
     try:
-        if Version(installed) not in REQUIRED_METAPHLAN_SPEC:
-            sys.exit(
-                "CRITICAL ERROR: Incompatible MetaPhlAn detected (found v{found}).\n"
-                "HUMAnN requires MetaPhlAn in the range {spec}.\n"
-                "Please install a compatible version, e.g.:\n\n"
-                "    pip install '{pin}'\n".format(
-                    found=installed, spec=str(REQUIRED_METAPHLAN_SPEC), pin=REQUIRED_METAPHLAN_PIN
-                )
-            )
+        supported = Version(installed) in REQUIRED_METAPHLAN_SPEC
     except Exception:
-        sys.exit("CRITICAL ERROR: Unable to parse installed MetaPhlAn version "
-                 "(got: {0}). Please reinstall MetaPhlAn within {1}.".format(installed, REQUIRED_METAPHLAN_SPEC))
+        _reject("CRITICAL ERROR: Unable to parse installed MetaPhlAn version "
+                "(got: {0}). Please reinstall MetaPhlAn within {1}.".format(
+                    installed, REQUIRED_METAPHLAN_SPEC))
+        return
+
+    if not supported:
+        _reject(
+            "CRITICAL ERROR: Incompatible MetaPhlAn detected (found v{found}).\n"
+            "HUMAnN requires MetaPhlAn in the range {spec}.\n"
+            "Please install a compatible version, e.g.:\n\n"
+            "    pip install '{pin}'\n".format(
+                found=installed, spec=str(REQUIRED_METAPHLAN_SPEC), pin=REQUIRED_METAPHLAN_PIN
+            )
+        )
+
+def _reject(message):
+    """
+    Abort the install, unless the user asked to proceed anyway
+    """
+    if os.environ.get(OVERRIDE_ENV_VAR):
+        sys.stderr.write(
+            message.replace("CRITICAL ERROR", "WARNING", 1) +
+            "\nProceeding because {0} is set. HUMAnN is not expected to work "
+            "with this MetaPhlAn.\n".format(OVERRIDE_ENV_VAR))
+        return
+    sys.exit(message)
 
 
 VERSION = "4.0.0.alpha.2"


### PR DESCRIPTION
## Description

`check_metaphlan_version()` calls `sys.exit` while `setup.py` is executing, so the `metaphlan>=4.0.0,<=4.1.2` pin cannot be worked around: it fires before dependency resolution, and `--no-deps` does not reach it. Anyone wanting to test HUMAnN against MetaPhlAn 4.2 — to work on #67, or to check what else breaks — has to edit `setup.py` first.

Setting `HUMANN_ALLOW_UNSUPPORTED_METAPHLAN` downgrades the rejection to a warning on stderr that still names the supported range and says HUMAnN is not expected to work:

```
$ HUMANN_ALLOW_UNSUPPORTED_METAPHLAN=1 pip install .
WARNING: Incompatible MetaPhlAn detected (found v4.2.6).
HUMAnN requires MetaPhlAn in the range >=4.0.0,<=4.1.2.
...
Proceeding because HUMANN_ALLOW_UNSUPPORTED_METAPHLAN is set. HUMAnN is not
expected to work with this MetaPhlAn.
```

The default is unchanged — an unsupported MetaPhlAn still aborts the install. This only gives people a way to opt into a configuration they already know is broken, which is what compatibility work requires.

I deliberately did **not** add `install_requires=["metaphlan..."]`. There is none today, and adding one would make pip install MetaPhlAn for users who get it from conda or a module system. The comment claiming pip installs it that way is removed, since it explains why an absent MetaPhlAn is not an error here.

Also records the supported MetaPhlAn range in the readme, where it was not stated.

## Tests

No automated test: `setup.py` runs `setuptools.setup()` at import, so the function is not importable in isolation without executing the install machinery. I exercised it by extracting the block and driving `_get_dist_version` — all eight combinations of {supported, unsupported, unparseable, absent} × {override set, unset} behave as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)