### PR TITLE
Updates for Metaphlan 4.2 compatibility

### DIFF
--- a/humann/search/prescreen.py
+++ b/humann/search/prescreen.py
@@ -196,8 +196,15 @@ def alignment(input):
     
     # outfile name
     bowtie2_out = utilities.name_temp_file(config.metaphlan_bowtie2_name) 
-
-    args=[input]+opts+["-o",config.profile_file,"--input_type",input_type, "--bowtie2out",bowtie2_out,"--offline"]
+    
+    #check metaphlan version to get parameters for bowtie2out.
+    metaphlan_version=check_metaphlan_version()
+    if(utilities.is_greater_version(metaphlan_version)):
+        bowtie2_call="--mapout"
+    else:
+        bowtie2_call="--bowtie2out"
+        
+    args=[input]+opts+["-o",config.profile_file,"--input_type",input_type, bowtie2_call,bowtie2_out,"--offline"]
     
     if config.threads >1:
         args+=["--nproc",config.threads]
@@ -241,6 +248,40 @@ def get_species_name(line, sgb=False):
         logger.debug("Unable to process species: " + line)
 
     return species                        
+
+def check_metaphlan_version(exe: str = "metaphlan"):
+    """
+    Checks to see what metaphlan verison is being run (not database verison). Returns the verison number.
+    """
+
+    #call metaphlan verison to get the verison number
+    try:
+        proc = subprocess.run(
+                [exe, "--version"],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        msg = (
+            f"\nERROR: Unable to run '{exe} --version'. "
+            f"Ensure MetaPhlAn is installed and in PATH.\n{e}"
+        )
+        logger.error(msg)
+        sys.exit(msg)
+
+    version_output = (proc.stdout or "") + (proc.stderr or "")
+    match=re.search(r"version\s+([0-9.]+)", version_output)
+
+    if(match):
+        version = match.group(1)
+    else:
+        message="could not identify metaphlan version when called metaphlan --version"
+        logger.error(message)
+        sys.exit("\n\nERROR: "+message)
+    return(version)
+
+    
 
 def create_custom_database(chocophlan_dir, profile_file):
     """

--- a/humann/utilities.py
+++ b/humann/utilities.py
@@ -1441,4 +1441,10 @@ def get_filtered_translated_alignments(alignment_file_tsv, alignments, apply_fil
                      str(small_identity_count))
         logger.debug("Total alignments not included based on small query coverage: " + 
                      str(small_query_coverage_count))
-    
+
+#checks if the current verison return is greater than or equal to the  minimum
+def is_greater_version(version, minimum="4.2.0"):
+    version_tuple = tuple(map(int, version.split(".")))
+    minimum_tuple = tuple(map(int, minimum.split(".")))
+
+    return version_tuple >= minimum_tuple

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,8 @@ except Exception:
             return None
         
 # ---- MetaPhlAn version requirement ----
-REQUIRED_METAPHLAN_SPEC = SpecifierSet(">=4.0.0,<=4.1.2")
-REQUIRED_METAPHLAN_PIN = "metaphlan>=4.0.0,<=4.1.2"
+REQUIRED_METAPHLAN_SPEC = SpecifierSet(">=4.0.0,<=4.2.0")
+REQUIRED_METAPHLAN_PIN = "metaphlan>=4.0.0,<=4.2.0"
 
 def check_metaphlan_version():
     """


### PR DESCRIPTION

## Description
- Update setup.py to accept metaphlan versions greater than 4.1. Please note that this branch is currently broken due to metaphlan database checks failing. I tested the following code invoking directly in python. 

- Updated search/prescreen to include a function to check metaphlan version and call the correct parameters within the alignment function depending on if the install version is greater than or equal to 4.2.0. 

- Added utility function to check if version output is greater than or equal to some specific major and minor release. Note that this could be accomplished with the package Version but wasn't clear if we wanted to bloat software with it or not. 


## Notes

Needs to be tested.
